### PR TITLE
Surfacing Command for Batch Setting Update Authority

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -141,8 +141,8 @@ pub enum SetSubcommands {
         new_update_authority: String,
     },
     /// Set update authority on multiple accounts to a new account
-    #[structopt(name = "batch-update-authority")]
-    UpdateMultipleAuthorities {
+    #[structopt(name = "update-authority-all")]
+    UpdateAuthorityAll {
         /// Path to the creator's keypair file
         #[structopt(short, long)]
         keypair: String,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -140,6 +140,21 @@ pub enum SetSubcommands {
         #[structopt(short = "u", long)]
         new_update_authority: String,
     },
+    /// Set update authority on multiple accounts to a new account
+    #[structopt(name = "batch-update-authority")]
+    UpdateMultipleAuthorities {
+        /// Path to the creator's keypair file
+        #[structopt(short, long)]
+        keypair: String,
+
+        /// Mint accounts of corresponding metadata to update
+        #[structopt(short, long)]
+        accounts: String,
+
+        /// New update authority address
+        #[structopt(short = "u", long)]
+        new_update_authority: String,
+    },
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -63,7 +63,7 @@ pub fn process_set(client: &RpcClient, commands: SetSubcommands) -> Result<()> {
         } => {
             set_update_authority(&client, &keypair, &account, &new_update_authority)
         }
-        SetSubcommands::UpdateMultipleAuthorities {
+        SetSubcommands::UpdateAuthorityAll {
             keypair,
             accounts,
             new_update_authority

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -60,7 +60,16 @@ pub fn process_set(client: &RpcClient, commands: SetSubcommands) -> Result<()> {
             keypair,
             account,
             new_update_authority,
-        } => set_update_authority(&client, &keypair, &account, &new_update_authority),
+        } => {
+            set_update_authority(&client, &keypair, &account, &new_update_authority)
+        }
+        SetSubcommands::UpdateMultipleAuthorities {
+            keypair,
+            accounts,
+            new_update_authority
+        } => {
+            set_update_authority_all(&client, &keypair, &accounts, &new_update_authority)
+        }
     }
 }
 

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -165,19 +165,27 @@ pub fn set_update_authority_all(
     client: &RpcClient,
     keypair: &String,
     json_file: &String,
+    new_update_authority: &String,
 ) -> Result<()> {
     let file = File::open(json_file)?;
-    let items: Vec<NewUpdateAuthority> = serde_json::from_reader(file)?;
+    let items: Vec<String> = serde_json::from_reader(file)?;
 
     for item in items.iter() {
-        println!("Updating metadata for mint account: {}", item.mint_account);
-        set_update_authority(
+        println!("Updating metadata for mint account: {}", item);
+
+        // If someone uses a json list that contains a mint account that has already
+        //  been updated this will throw an error. We print that error and continue
+        let _ = match set_update_authority(
             client,
             keypair,
-            &item.mint_account,
-            &item.new_update_authority,
-        )?;
+            &item,
+            &new_update_authority,
+        ) {
+            Ok(_) => {}
+            Err(error) => {
+                println!("Error occurred! {}", error)
+            }
+        };
     }
-
     Ok(())
 }


### PR DESCRIPTION
I made a few changes to the file the command is expecting. I view this as being used in conjunction with the snapshot command to get the mint accounts and therefore moved the update authority input into the arguments as opposed to the file. 