### PR TITLE
feat(update): Update seller fee basis points of existing token

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,3 +489,15 @@ Update the metadata URI, keeping the rest of the `Data` struct the same.
 ```bash
 metaboss update uri --keypair <PATH_TO_KEYPAIR> --account <MINT_ACCOUNT> --new-uri <NEW_URI>
 ```
+Outputs a TxId to the command line so you can check the result.
+
+#### Update Seller Fee Basis Points
+
+Update the data sellerFeeBasisPoints, keeping the rest of the `Data` struct the same.
+
+##### Usage
+
+```bash
+metaboss update sellerfeebasispoints --keypair <PATH_TO_KEYPAIR> --account <MINT_ACCOUNT> -s <NEW_PRICE>
+```
+Outputs a TxId to the command line so you can check the result.

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -268,4 +268,19 @@ pub enum UpdateSubcommands {
         #[structopt(short = "u", long)]
         new_uri: String,
     },
+    /// Update the sellerFeeBasisPoints, keeping the rest of the data the same
+    #[structopt(name = "sellerfeebasispoints")]
+    SellerFeeBasisPoints {
+        /// Path to the creator's keypair file
+        #[structopt(short, long)]
+        keypair: String,
+
+        /// Mint account of corresponding metadata to update
+        #[structopt(short, long)]
+        account: String,
+
+        /// New uri
+        #[structopt(short = "s", long)]
+        new_basis_points: u16,
+    },
 }

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -48,6 +48,11 @@ pub fn process_update(client: &RpcClient, commands: UpdateSubcommands) -> Result
             account,
             new_uri,
         } => update_uri(&client, &keypair, &account, &new_uri),
+        UpdateSubcommands::SellerFeeBasisPoints {
+            keypair,
+            account,
+            new_basis_points,
+        } => update_seller_fee_basis(&client, &keypair, &account, new_basis_points),
     }
 }
 


### PR DESCRIPTION
### Description:
Creating command to quickly update seller fee basis points of minted token

### Usage:
`metaboss update sellerfeebasispoints --keypair <PATH_TO_KEYPAIR> --account <MINT_ACCOUNT> -s <NEW_PRICE>`