### PR TITLE
Fix JSON encoding of `creators` field.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -185,7 +185,7 @@ fn decode_to_json(metadata: Metadata) -> AnyResult<Value> {
         "symbol": metadata.data.symbol.to_string().trim_matches(char::from(0)),
         "seller_fee_basis_points": metadata.data.seller_fee_basis_points,
         "uri": metadata.data.uri.to_string().trim_matches(char::from(0)),
-        "creators": [creators],
+        "creators": creators,
     });
 
     let json_metadata = json!({


### PR DESCRIPTION
The currently code generates JSON output like:

```
{"data":{"creators":[[{"address":"FEg3mmpcrcRsVTuc2n3oghHpRvAtEJJau4KWjaPpLKcA","share":0,"verified":true},{"address":"B5MPcaEGNF3iZH5kLjPPfhy3ieXbQ8Cgb77zSZD6gNSn","share":11,"verified":false},{"address":"uVZUoHE3W7YExtqU6cP7Vygk48noZvrMJorpuvHn1d7","share":7,"verified":false},{"address":"GR2uBCDumKagmEiGDjYsq8GjKogmbJwnfpJ14G7gxhB8","share":31,"verified":false},{"address":"GviBsqVaruw32UP6C4YMFhBffJFmoyFt65qFnJPUcgta","share":51,"verified":false}]],"name":"Galactic Gecko #5452","seller_fee_basis_points":500,"symbol":"GGSG","uri":"https://arweave.net/ULcteflMWuWWj9iCbK773xRgLhFEtwjVr8LTOy9ROoA"},"edition_nonce":255,"is_mutable":true,"key":"MetadataV1","mint":"1257AGGiM3zaYMj6LycLM1PaG8aVnk1DXHxda7X2LB2H","primary_sale_happened":true,"update_authority":"CeS4fWuRz44kUf5aHJZW62LD8GJkPabLsChA5Zn2rLiS"}
```

Where `creators` is in a double array.

Remove the outer array for proper encoding.