### PR TITLE
fix build issue in withdraw.rs

### DIFF
--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -50,8 +50,8 @@ pub fn withdraw(args: WithdrawArgs) -> Result<()> {
     let sol = account.lamports as f64 / LAMPORTS_PER_SOL as f64;
 
     println!(
-        "Withdrawing {sol} SOL from candy machine {}",
-        &candy_machine
+        "Withdrawing {} SOL from candy machine {}",
+        sol, &candy_machine
     );
     let sig = program
         .request()


### PR DESCRIPTION
Was just a string format issue. Stopped me from being able to build the 0.3.6 crate with `cargo install metaboss` though.