### PR TITLE
Add SSC DAO RPC to rate limit list

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,6 +16,7 @@ pub const PUBLIC_RPC_URLS: &'static [&'static str] = &[
     "https://api.testnet.solana.com",
     "https://api.mainnet-beta.solana.com",
     "https://solana-api.projectserum.com",
+    "https://ssc-dao.genesysgo.net",
 ];
 
 pub const MAX_REQUESTS: u64 = 40;


### PR DESCRIPTION
Added to respect the new rate limit of the SSC DAO RPC Endpoint.

There may be potential to modify the rate limit constants to be more specific for the SSC DAO endpoint, but this is a good start I think.