### PR TITLE
Feature sign mints

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -163,7 +163,7 @@ pub enum MintSubcommands {
         primary_sale_happened: bool,
 
         /// Sign NFT after minting it
-        #[structopt(short, long)]
+        #[structopt(long)]
         sign: bool,
     },
     #[structopt(name = "list")]
@@ -194,7 +194,7 @@ pub enum MintSubcommands {
         primary_sale_happened: bool,
 
         /// Sign NFTs after minting them
-        #[structopt(short, long)]
+        #[structopt(long)]
         sign: bool,
     },
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -161,6 +161,10 @@ pub enum MintSubcommands {
         /// Mint the NFT with primary_sale_happened set to true
         #[structopt(short, long)]
         primary_sale_happened: bool,
+
+        /// Sign NFT after minting it
+        #[structopt(short, long)]
+        sign: bool,
     },
     #[structopt(name = "list")]
     /// Mint a list of NFTs from a directory of JSON files
@@ -188,6 +192,10 @@ pub enum MintSubcommands {
         /// Mint the NFTs with primary_sale_happened set to true
         #[structopt(short, long)]
         primary_sale_happened: bool,
+
+        /// Sign NFTs after minting them
+        #[structopt(short, long)]
+        sign: bool,
     },
 }
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -103,7 +103,7 @@ pub enum DecodeSubcommands {
         full: bool,
 
         /// Path to JSON file containing a list of mint accounts to decode
-        #[structopt(short, long)]
+        #[structopt(short = "L", long)]
         list_file: Option<String>,
 
         /// Path to directory to save output files.
@@ -143,7 +143,7 @@ pub enum MintSubcommands {
         keypair: String,
 
         /// Receiving address, if different from update authority.
-        #[structopt(short, long)]
+        #[structopt(short = "R", long)]
         receiver: Option<String>,
 
         /// On-chain formatted metadata for the new NFT
@@ -174,7 +174,7 @@ pub enum MintSubcommands {
         keypair: String,
 
         /// Receiving address, if different from update authority
-        #[structopt(short, long)]
+        #[structopt(short = "R", long)]
         receiver: Option<String>,
 
         /// Directory of on-chain formatted metadata files for the new NFTs

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -47,6 +47,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             external_metadata_uri,
             immutable,
             primary_sale_happened,
+            sign,
         } => mint_one(
             &client,
             &keypair,
@@ -55,6 +56,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             external_metadata_uri.as_ref(),
             immutable,
             primary_sale_happened,
+            sign,
         ),
         MintSubcommands::List {
             keypair,
@@ -63,6 +65,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             external_metadata_uris,
             immutable,
             primary_sale_happened,
+            sign,
         } => mint_list(
             &client,
             keypair,
@@ -71,6 +74,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             external_metadata_uris,
             immutable,
             primary_sale_happened,
+            sign,
         ),
     }
 }


### PR DESCRIPTION
Just a quality of life update. Found myself having to run the sign all command quite often after minting through metaboss. Added a flag to sign each NFT as it mints instead. 