### PR TITLE
feat: added the feature to fetch holders when passed a mint list file

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -315,6 +315,10 @@ pub enum SnapshotSubcommands {
         #[structopt(long = "v2")]
         v2: bool,
 
+        /// Path to JSON file with list of mint accounts to sign
+        #[structopt(short, long)]
+        mint_accounts_file: Option<String>,
+
         /// Path to directory to save output files.
         #[structopt(short, long, default_value = ".")]
         output: String,

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -126,9 +126,10 @@ pub fn process_snapshot(client: &RpcClient, commands: SnapshotSubcommands) -> Re
         SnapshotSubcommands::Holders {
             update_authority,
             candy_machine_id,
+            mint_accounts_file,
             v2,
             output,
-        } => snapshot_holders(&client, &update_authority, &candy_machine_id, v2, &output),
+        } => snapshot_holders(&client, &update_authority, &candy_machine_id, &mint_accounts_file, v2, &output),
         SnapshotSubcommands::CMAccounts {
             update_authority,
             output,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -28,11 +28,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::constants::*;
 use crate::derive::derive_cmv2_pda;
 use crate::limiter::create_rate_limiter;
 use crate::parse::{first_creator_is_verified, is_only_one_option};
 use crate::spinner::*;
+use crate::{constants::*, decode::get_metadata_pda};
 
 #[derive(Debug, Serialize, Clone)]
 struct Holder {
@@ -131,6 +131,7 @@ pub fn snapshot_holders(
     client: &RpcClient,
     update_authority: &Option<String>,
     candy_machine_id: &Option<String>,
+    mint_accounts_file: &Option<String>,
     v2: bool,
     output: &String,
 ) -> Result<()> {
@@ -150,9 +151,13 @@ pub fn snapshot_holders(
         } else {
             get_cm_creator_accounts(client, &candy_machine_id)?
         }
+    } else if let Some(mint_accounts_file) = mint_accounts_file {
+        let file = File::open(mint_accounts_file)?;
+        let mint_accounts: Vec<String> = serde_json::from_reader(&file)?;
+        get_mint_account_infos(client, mint_accounts)?
     } else {
         return Err(anyhow!(
-            "Must specify either --update-authority or --candy-machine-id"
+            "Must specify either --update-authority or --candy-machine-id or --mint-accounts-file"
         ));
     };
     spinner.finish_with_message("Getting accounts...Done!");
@@ -248,9 +253,11 @@ pub fn snapshot_holders(
         update_authority
     } else if let Some(candy_machine_id) = candy_machine_id {
         candy_machine_id
+    } else if let Some(mint_accounts_file) = mint_accounts_file {
+        mint_accounts_file
     } else {
         return Err(anyhow!(
-            "Must specify either --update-authority or --candy-machine-id"
+            "Must specify either --update-authority or --candy-machine-id or --mint-accounts-file"
         ));
     };
 
@@ -258,6 +265,53 @@ pub fn snapshot_holders(
     serde_json::to_writer(&mut file, &nft_holders)?;
 
     Ok(())
+}
+
+fn get_mint_account_infos(
+    client: &RpcClient,
+    mint_accounts: Vec<String>,
+) -> Result<Vec<(Pubkey, Account)>> {
+    let use_rate_limit = *USE_RATE_LIMIT.read().unwrap();
+    let handle = create_rate_limiter();
+
+    let address_account_pairs: Arc<Mutex<Vec<(Pubkey, Account)>>> =
+        Arc::new(Mutex::new(Vec::new()));
+
+    mint_accounts
+        .par_iter()
+        .progress()
+        .for_each(|mint_account| {
+            let mut handle = handle.clone();
+            if use_rate_limit {
+                handle.wait();
+            }
+
+            let mint_pubkey = match Pubkey::from_str(mint_account) {
+                Ok(pubkey) => pubkey,
+                Err(_) => {
+                    error!("Invalid mint address {}", mint_account);
+                    return;
+                }
+            };
+
+            let metadata_pubkey = get_metadata_pda(mint_pubkey);
+
+            let account_info = match client.get_account(&metadata_pubkey) {
+                Ok(account) => account,
+                Err(_) => {
+                    error!("Error in fetching metadata for mint {}", mint_account);
+                    return;
+                }
+            };
+
+            address_account_pairs
+                .lock()
+                .unwrap()
+                .push((mint_pubkey, account_info))
+        });
+
+    let res = address_account_pairs.lock().unwrap().clone();
+    Ok(res)
 }
 
 fn get_mints_by_update_authority(


### PR DESCRIPTION
The snapshot command now has a feature to get the holders list from a mint list file. Screenshots are attached beneath for the mint list and the corresponding holders's list

## Example command API:
`metaboss snapshot holders -m demo-holders.json -r https://ssc-dao.genesysgo.net/`

## Screenshot:
<img width="2196" alt="Screenshot 2022-02-21 at 8 21 31 AM" src="https://user-images.githubusercontent.com/32637757/154881256-ed981acb-26ed-4ffe-8ef2-08eb42d5e717.png">
