### PR TITLE
feat: updated snapshot command to support creator position

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -414,10 +414,6 @@ pub enum UpdateSubcommands {
         #[structopt(short = "c", long)]
         new_creator: String,
 
-        /// New share percentage for the creator
-        #[structopt(short = "s", long)]
-        new_share: u8,
-
         /// Index position for changing the address
         #[structopt(short, long, default_value = "0")]
         position: usize,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -277,16 +277,20 @@ pub enum SignSubcommands {
         #[structopt(short, long)]
         account: String,
     },
-    /// Sign all metadata from a JSON list or for a given candy machine id
+    /// Sign all metadata from a JSON list or for a given candy machine id / creator
     #[structopt(name = "all")]
     All {
         /// Path to the creator's keypair file
         #[structopt(short, long)]
         keypair: String,
 
-        /// Candy Machine ID to filter accounts by
+        /// Creator to filter accounts by (for CM v2 use --v2 if candy_machine account is passed)
         #[structopt(short, long)]
-        candy_machine_id: Option<String>,
+        creator: Option<String>,
+
+        /// CM creator index to filter by
+        #[structopt(short, long, default_value = "0")]
+        position: usize,
 
         /// Candy machine v2 id
         #[structopt(long = "v2")]
@@ -300,16 +304,20 @@ pub enum SignSubcommands {
 
 #[derive(Debug, StructOpt)]
 pub enum SnapshotSubcommands {
-    /// Snapshot all current holders of NFTs by candy_machine_id or update_authority
+    /// Snapshot all current holders of NFTs by candy_machine_id / creator or update_authority
     #[structopt(name = "holders")]
     Holders {
         /// Update authority to filter accounts by.
         #[structopt(short, long)]
         update_authority: Option<String>,
 
-        /// Candy Machine ID to filter accounts by.
+        /// Creator to filter accounts by (for CM v2 use --v2 if candy_machine account is passed)
         #[structopt(short, long)]
-        candy_machine_id: Option<String>,
+        creator: Option<String>,
+
+        /// CM creator index to filter by
+        #[structopt(short, long, default_value = "0")]
+        position: usize,
 
         /// Candy machine v2 id
         #[structopt(long = "v2")]
@@ -334,12 +342,16 @@ pub enum SnapshotSubcommands {
         #[structopt(short, long, default_value = ".")]
         output: String,
     },
-    /// Snapshot all mint accounts for a given candy machine id or update authority
+    /// Snapshot all mint accounts for a given candy_machine_id / creatoro or update authority
     #[structopt(name = "mints")]
     Mints {
-        /// Candy Machine ID to filter accounts by
+        /// Creator to filter accounts by (for CM v2 use --v2 if candy_machine account is passed)
         #[structopt(short, long)]
-        candy_machine_id: Option<String>,
+        creator: Option<String>,
+
+        /// CM creator index to filter by
+        #[structopt(short, long, default_value = "0")]
+        position: usize,
 
         /// Update authority to filter accounts by.
         #[structopt(short, long)]

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -177,16 +177,8 @@ pub fn process_update(client: &RpcClient, commands: UpdateSubcommands) -> Result
             keypair,
             account,
             new_creator,
-            new_share,
             position,
-        } => update_creator_by_position(
-            &client,
-            &keypair,
-            &account,
-            &new_creator,
-            new_share,
-            position,
-        ),
+        } => update_creator_by_position(&client, &keypair, &account, &new_creator, position),
         UpdateSubcommands::Data {
             keypair,
             account,

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -114,10 +114,18 @@ pub fn process_sign(client: &RpcClient, commands: SignSubcommands) -> Result<()>
         SignSubcommands::One { keypair, account } => sign_one(&client, keypair, account),
         SignSubcommands::All {
             keypair,
-            candy_machine_id,
+            creator,
+            position,
             v2,
             mint_accounts_file,
-        } => sign_all(&client, &keypair, candy_machine_id, v2, mint_accounts_file),
+        } => sign_all(
+            &client,
+            &keypair,
+            &creator,
+            position,
+            v2,
+            mint_accounts_file,
+        ),
     }
 }
 
@@ -125,21 +133,31 @@ pub fn process_snapshot(client: &RpcClient, commands: SnapshotSubcommands) -> Re
     match commands {
         SnapshotSubcommands::Holders {
             update_authority,
-            candy_machine_id,
+            creator,
+            position,
             mint_accounts_file,
             v2,
             output,
-        } => snapshot_holders(&client, &update_authority, &candy_machine_id, &mint_accounts_file, v2, &output),
+        } => snapshot_holders(
+            &client,
+            &update_authority,
+            &creator,
+            position,
+            &mint_accounts_file,
+            v2,
+            &output,
+        ),
         SnapshotSubcommands::CMAccounts {
             update_authority,
             output,
         } => snapshot_cm_accounts(&client, &update_authority, &output),
         SnapshotSubcommands::Mints {
-            candy_machine_id,
+            creator,
+            position,
             update_authority,
             v2,
             output,
-        } => snapshot_mints(&client, candy_machine_id, update_authority, v2, output),
+        } => snapshot_mints(&client, &creator, position, update_authority, v2, output),
     }
 }
 


### PR DESCRIPTION
This feature makes sure users can snapshot a creator within any index of the creator's array. Also makes sure to not exceed the index by 4.

## Screenshot
1. Snapshot mints
<img width="1198" alt="Screenshot 2022-02-25 at 11 23 25 AM" src="https://user-images.githubusercontent.com/32637757/155662084-b73b1b2d-eb3a-44df-b4f9-3c93e024cb87.png">

2. Snapshot holders
<img width="1460" alt="Screenshot 2022-02-25 at 11 24 20 AM" src="https://user-images.githubusercontent.com/32637757/155662177-faad4fb6-1dde-4abc-b5d2-d6330813b387.png">

