### PR TITLE
Update creators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "metaboss"
-version = "0.4.2-beta"
+version = "0.5.0-beta"
 dependencies = [
  "anchor-client",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metaboss"
-version = "0.4.2-beta"
+version = "0.5.0-beta"
 edition = "2021"
 description="The Metaplex NFT-standard Swiss Army Knife tool."
 repository="https://github.com/samuelvanderwaal/metaboss"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
-v0.4.2
+v0.5.0
 * Update metadata by name, symbol & creator
 * Add `sign` option to mint commands
 * Change rate limiting for GenesysGo and allow custom rate limits
+* Snapshot by creator and position
 
 v0.4.1
 * Hot fix: add rate-limiting to all par_iter functions

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -418,10 +418,6 @@ pub enum UpdateSubcommands {
         #[structopt(short = "c", long)]
         new_creators: String,
 
-        /// Index position for changing the address
-        #[structopt(short, long, default_value = "0")]
-        position: usize,
-
         /// Should be appended instead of overwriting
         #[structopt(short, long = "append")]
         append: bool,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -414,9 +414,9 @@ pub enum UpdateSubcommands {
         #[structopt(short, long)]
         account: String,
 
-        /// New name for the metadata
+        /// New creators in the format: address1:share:verified,address2:share:verified,...
         #[structopt(short = "c", long)]
-        new_creator: String,
+        new_creators: String,
 
         /// Index position for changing the address
         #[structopt(short, long, default_value = "0")]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -421,6 +421,10 @@ pub enum UpdateSubcommands {
         /// Index position for changing the address
         #[structopt(short, long, default_value = "0")]
         position: usize,
+
+        /// Should be appended instead of overwriting
+        #[structopt(short, long = "append")]
+        append: bool,
     },
     /// Update the data struct on a NFT
     #[structopt(name = "data")]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -166,6 +166,7 @@ pub fn parse_cli_creators(new_creators: String, should_append: bool) -> Result<V
         let address = Pubkey::from_str(&address)
             .map_err(|_| anyhow!(format!("Invalid creator address: {:?}!", address)))?;
         let share = if should_append {
+            c.next();
             0u8
         } else {
             c.next()

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -187,6 +187,10 @@ pub fn parse_cli_creators(new_creators: String) -> Result<Vec<Creator>> {
         return Err(anyhow!("Creators shares must sum to 100!"));
     }
 
+    if creators.len() > 5 {
+        return Err(anyhow!("Too many creators: maximum of five!"));
+    }
+
     Ok(creators)
 }
 

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -184,9 +184,9 @@ pub fn process_update(client: &RpcClient, commands: UpdateSubcommands) -> Result
         UpdateSubcommands::Creators {
             keypair,
             account,
-            new_creator,
+            new_creators,
             position,
-        } => update_creator_by_position(&client, &keypair, &account, &new_creator, position),
+        } => update_creator_by_position(&client, &keypair, &account, &new_creators, position),
         UpdateSubcommands::Data {
             keypair,
             account,

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -186,7 +186,10 @@ pub fn process_update(client: &RpcClient, commands: UpdateSubcommands) -> Result
             account,
             new_creators,
             position,
-        } => update_creator_by_position(&client, &keypair, &account, &new_creators, position),
+            append,
+        } => {
+            update_creator_by_position(&client, &keypair, &account, &new_creators, position, append)
+        }
         UpdateSubcommands::Data {
             keypair,
             account,

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -185,11 +185,8 @@ pub fn process_update(client: &RpcClient, commands: UpdateSubcommands) -> Result
             keypair,
             account,
             new_creators,
-            position,
             append,
-        } => {
-            update_creator_by_position(&client, &keypair, &account, &new_creators, position, append)
-        }
+        } => update_creator_by_position(&client, &keypair, &account, &new_creators, append),
         UpdateSubcommands::Data {
             keypair,
             account,

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -15,6 +15,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use std::{
+    cmp,
     fs::File,
     path::Path,
     str::FromStr,
@@ -72,15 +73,8 @@ pub fn update_creator_by_position(
     keypair: &String,
     mint_account: &String,
     new_creators: &String,
-    position: usize,
     should_append: bool,
 ) -> Result<()> {
-    // Creators cannot be greater than 5
-    if position > 4 {
-        error!("Invalid position provided; max number of five creators are allowed");
-        std::process::exit(1);
-    }
-
     let parsed_keypair = parse_keypair(keypair)?;
     let data_with_old_creators = decode(client, mint_account)?.data;
     let parsed_creators = parse_cli_creators(new_creators.to_string(), should_append)?;
@@ -94,7 +88,8 @@ pub fn update_creator_by_position(
                 "Appending {} new creators with old creators",
                 remaining_space
             );
-            old_creators.append(&mut parsed_creators[0..remaining_space].to_vec());
+            let end_index = cmp::min(parsed_creators.len(), remaining_space);
+            old_creators.append(&mut parsed_creators[0..end_index].to_vec());
             old_creators
         }
     } else {

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -85,8 +85,8 @@ pub fn update_creator_by_position(
         } else {
             let remaining_space = 5 - old_creators.len();
             warn!(
-                "Appending {} new creators with old creators",
-                remaining_space
+                "Appending {} new creators with old creators with shares of 0",
+                parsed_creators.len()
             );
             let end_index = cmp::min(parsed_creators.len(), remaining_space);
             old_creators.append(&mut parsed_creators[0..end_index].to_vec());


### PR DESCRIPTION
This changes `update creators` to allow updating multiple creators with full options instead of just swapping out a single address. 

API:

```
metaboss update creators -k <keypair> --creators <ADDRESS1>:<SHARE>:<VERIFIED>,<ADDRESS2>:<SHARE>:<VERIFIED>
```

