### PR TITLE
Fix quick node RPC 404 not found issue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,6 @@ fn main() -> Result<()> {
         }
     };
 
-    // Remove trailing slash
-    let rpc = if rpc.ends_with('/') {
-        rpc.trim_end_matches('/').to_string()
-    } else {
-        rpc
-    };
-
     // Set rate limiting if the user specified a public RPC.
     if PUBLIC_RPC_URLS.contains(&rpc.as_str()) {
         warn!(


### PR DESCRIPTION
Looks like this part of the code which removes the trailing / is breaking quick node RPC as looks like quick node relies on the trailing / for their RPC to work. This PR reverts it back.


![image](https://user-images.githubusercontent.com/18750503/157143176-10865967-6bd9-4633-899d-3c76c4ab2c92.png)
