### PR TITLE
allow use of different payer for set update-authority

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -473,6 +473,10 @@ pub enum SetSubcommands {
         /// New update authority address
         #[structopt(short = "u", long)]
         new_update_authority: String,
+
+        //Path to the payers's keypair file
+        #[structopt(short = "p", long)]
+        keypair_payer: Option<String>,
     },
     /// Set update authority on multiple accounts to a new account
     #[structopt(name = "update-authority-all")]
@@ -488,6 +492,10 @@ pub enum SetSubcommands {
         /// New update authority address
         #[structopt(short = "u", long)]
         new_update_authority: String,
+
+        //Path to the payers's keypair file
+        #[structopt(short = "p", long)]
+        keypair_payer: Option<String>,
     },
     /// Set is-mutable to false, preventing any future updates to the NFT
     #[structopt(name = "immutable")]

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -226,12 +226,14 @@ pub fn process_set(client: &RpcClient, commands: SetSubcommands) -> Result<()> {
             keypair,
             account,
             new_update_authority,
-        } => set_update_authority(client, keypair, &account, &new_update_authority),
+            keypair_payer
+        } => set_update_authority(client, keypair, &account, &new_update_authority, keypair_payer),
         SetSubcommands::UpdateAuthorityAll {
             keypair,
             mint_accounts_file,
             new_update_authority,
-        } => set_update_authority_all(client, keypair, &mint_accounts_file, &new_update_authority),
+            keypair_payer
+        } => set_update_authority_all(client, keypair, &mint_accounts_file, &new_update_authority, keypair_payer),
         SetSubcommands::Immutable { keypair, account } => set_immutable(client, keypair, &account),
         SetSubcommands::ImmutableAll {
             keypair,

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -226,14 +226,26 @@ pub fn process_set(client: &RpcClient, commands: SetSubcommands) -> Result<()> {
             keypair,
             account,
             new_update_authority,
-            keypair_payer
-        } => set_update_authority(client, keypair, &account, &new_update_authority, keypair_payer),
+            keypair_payer,
+        } => set_update_authority(
+            client,
+            keypair,
+            &account,
+            &new_update_authority,
+            keypair_payer,
+        ),
         SetSubcommands::UpdateAuthorityAll {
             keypair,
             mint_accounts_file,
             new_update_authority,
-            keypair_payer
-        } => set_update_authority_all(client, keypair, &mint_accounts_file, &new_update_authority, keypair_payer),
+            keypair_payer,
+        } => set_update_authority_all(
+            client,
+            keypair,
+            &mint_accounts_file,
+            &new_update_authority,
+            keypair_payer,
+        ),
         SetSubcommands::Immutable { keypair, account } => set_immutable(client, keypair, &account),
         SetSubcommands::ImmutableAll {
             keypair,

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -397,14 +397,14 @@ pub fn set_update_authority(
     keypair_path: Option<String>,
     mint_account: &str,
     new_update_authority: &str,
-    keypair_payer_path: Option<String>
+    keypair_payer_path: Option<String>,
 ) -> Result<()> {
     let solana_opts = parse_solana_config();
     let keypair = parse_keypair(keypair_path.clone(), solana_opts);
-    
+
     let solana_opts = parse_solana_config();
     let keypair_payer = parse_keypair(keypair_payer_path.or(keypair_path), solana_opts);
-        
+
     let program_id = Pubkey::from_str(METAPLEX_PROGRAM_ID)?;
     let mint_pubkey = Pubkey::from_str(mint_account)?;
 
@@ -441,7 +441,7 @@ pub fn set_update_authority_all(
     keypair_path: Option<String>,
     json_file: &str,
     new_update_authority: &str,
-    keypair_payer_path: Option<String>
+    keypair_payer_path: Option<String>,
 ) -> Result<()> {
     let use_rate_limit = *USE_RATE_LIMIT.read().unwrap();
     let handle = create_rate_limiter();
@@ -458,8 +458,13 @@ pub fn set_update_authority_all(
 
         // If someone uses a json list that contains a mint account that has already
         //  been updated this will throw an error. We print that error and continue
-        let _ = match set_update_authority(client, keypair_path.clone(), item, new_update_authority, keypair_payer_path.clone())
-        {
+        let _ = match set_update_authority(
+            client,
+            keypair_path.clone(),
+            item,
+            new_update_authority,
+            keypair_payer_path.clone(),
+        ) {
             Ok(_) => {}
             Err(error) => {
                 error!("Error occurred! {}", error)

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -397,10 +397,14 @@ pub fn set_update_authority(
     keypair_path: Option<String>,
     mint_account: &str,
     new_update_authority: &str,
+    keypair_payer_path: Option<String>
 ) -> Result<()> {
     let solana_opts = parse_solana_config();
-    let keypair = parse_keypair(keypair_path, solana_opts);
-
+    let keypair = parse_keypair(keypair_path.clone(), solana_opts);
+    
+    let solana_opts = parse_solana_config();
+    let keypair_payer = parse_keypair(keypair_payer_path.or(keypair_path), solana_opts);
+        
     let program_id = Pubkey::from_str(METAPLEX_PROGRAM_ID)?;
     let mint_pubkey = Pubkey::from_str(mint_account)?;
 
@@ -420,8 +424,8 @@ pub fn set_update_authority(
     let recent_blockhash = client.get_latest_blockhash()?;
     let tx = Transaction::new_signed_with_payer(
         &[ix],
-        Some(&update_authority),
-        &[&keypair],
+        Some(&keypair_payer.pubkey()),
+        &[&keypair, &keypair_payer],
         recent_blockhash,
     );
 
@@ -437,6 +441,7 @@ pub fn set_update_authority_all(
     keypair_path: Option<String>,
     json_file: &str,
     new_update_authority: &str,
+    keypair_payer_path: Option<String>
 ) -> Result<()> {
     let use_rate_limit = *USE_RATE_LIMIT.read().unwrap();
     let handle = create_rate_limiter();
@@ -453,7 +458,7 @@ pub fn set_update_authority_all(
 
         // If someone uses a json list that contains a mint account that has already
         //  been updated this will throw an error. We print that error and continue
-        let _ = match set_update_authority(client, keypair_path.clone(), item, new_update_authority)
+        let _ = match set_update_authority(client, keypair_path.clone(), item, new_update_authority, keypair_payer_path.clone())
         {
             Ok(_) => {}
             Err(error) => {


### PR DESCRIPTION
Hey!
In some cases it can happen that it is not possible to send funds to the update authority even though one has access to it. (Current example: A project with a rogue dev that is transferring all funds out of the authority wallet all the time. For this project it's not possible to change the update authority, metadata etc.)

The change here allows to add a --keypair-payer option and use another wallet to pay the transaction.
```
./metaboss set update-authority-all --keypair updateAuthority.json --mint-accounts-file nfts.json --new-update-authority <public key> -p keypairPayer.json
```

If no payer is provided the keypair option would be used as payer (or if that is not provided the solana config).

Tested in devnet and mainnet already.

Regards!