### PR TITLE
update readme with new minimum rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cargo install metaboss
 
 ### Install From Source
 
-Requires Rust 1.56 or later.
+Requires Rust 1.60 or later.
 
 Install [Rust](https://www.rust-lang.org/tools/install).
 


### PR DESCRIPTION
docs: update min rust version to v1.60 or later in readme

resolves #117