### PR TITLE
add update seller-fee-basis-points-all

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -30,6 +30,12 @@ pub struct UpdateUriData {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateSellerFeesData {
+    pub mint_account: String,
+    pub new_seller_fee_basis_points: u16,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NFTCreator {
     pub address: String,
     pub verified: bool,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -752,6 +752,17 @@ pub enum UpdateSubcommands {
         #[structopt(short, long)]
         new_seller_fee_basis_points: u16,
     },
+    /// Update the metadata seller fee basis points on a list of mint accounts
+    #[structopt(name = "seller-fee-basis-points-all")]
+    SellerFeeBasisPointsAll {
+        /// Path to the creator's keypair file
+        #[structopt(short, long)]
+        keypair: Option<String>,
+
+        /// JSON file with list of mint accounts and new seller fee basis points
+        #[structopt(short = "u", long)]
+        json_file: String,
+    },
     /// Update the name field inside the data struct on an NFT
     #[structopt(name = "name")]
     Name {

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -377,6 +377,14 @@ pub fn process_update(client: &RpcClient, commands: UpdateSubcommands) -> Result
             &account,
             &new_seller_fee_basis_points,
         ),
+        UpdateSubcommands::SellerFeeBasisPointsAll {
+            keypair,
+            json_file
+        } => update_seller_fee_basis_points_all(
+            client,
+            keypair,
+            &json_file
+        ),
         UpdateSubcommands::Name {
             keypair,
             account,

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -377,14 +377,9 @@ pub fn process_update(client: &RpcClient, commands: UpdateSubcommands) -> Result
             &account,
             &new_seller_fee_basis_points,
         ),
-        UpdateSubcommands::SellerFeeBasisPointsAll {
-            keypair,
-            json_file
-        } => update_seller_fee_basis_points_all(
-            client,
-            keypair,
-            &json_file
-        ),
+        UpdateSubcommands::SellerFeeBasisPointsAll { keypair, json_file } => {
+            update_seller_fee_basis_points_all(client, keypair, &json_file)
+        }
         UpdateSubcommands::Name {
             keypair,
             account,

--- a/src/update_metadata.rs
+++ b/src/update_metadata.rs
@@ -19,7 +19,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::data::{NFTData, UpdateNFTData, UpdateUriData,UpdateSellerFeesData};
+use crate::data::{NFTData, UpdateNFTData, UpdateSellerFeesData, UpdateUriData};
 use crate::decode::{decode, get_metadata_pda};
 use crate::limiter::create_default_rate_limiter;
 use crate::parse::{convert_local_to_remote_data, parse_cli_creators, parse_keypair};
@@ -40,10 +40,18 @@ pub fn update_seller_fee_basis_points_all(
         if use_rate_limit {
             handle.wait();
         }
-        match update_seller_fee_basis_points_one(client, keypair, &data.mint_account, &data.new_seller_fee_basis_points) {
+        match update_seller_fee_basis_points_one(
+            client,
+            keypair,
+            &data.mint_account,
+            &data.new_seller_fee_basis_points,
+        ) {
             Ok(_) => (),
             Err(e) => {
-                error!("Failed to update new_seller_fee_basis_points: {:?} error: {}", data, e);
+                error!(
+                    "Failed to update new_seller_fee_basis_points: {:?} error: {}",
+                    data, e
+                );
             }
         }
     });


### PR DESCRIPTION
This PR adds the ability to update the sellers fee on a JSON list of mints and new seller fees, similar to the update uri-all. 

`
[
    {
        "mint_account": "5tQKjHyJx9..........wuDdXr3kHd",
        "new_seller_fee_basis_points": 1000
    },
    {
        "mint_account": "5n2gDhH.........twnCAqzKYhTrGnV",
        "new_seller_fee_basis_points": 1000
    }
]
`