### PR TITLE
feat: add create metadata & fungible commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "strsim 0.10.0",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,15 +1842,17 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.3.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029a329d7a89f7a3caf0b91bec307531f4b6c9cca34aa775454845fbbd05ac57"
+checksum = "3119638ec12fd1ca948c8ca62fdeb46c7118cc1bf670b4688913ed7f00a789e9"
 dependencies = [
  "arrayref",
  "borsh",
  "mpl-token-vault",
  "num-derive",
  "num-traits",
+ "serde",
+ "serde_with",
  "shank",
  "solana-program",
  "spl-associated-token-account",
@@ -2883,6 +2926,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ indicatif = { version = "0.16.2", features = ["rayon"] }
 lazy_static = "1.4.0"
 log = "0.4.14"
 metaboss_lib = "0.0.4"
-mpl-token-metadata = "1.3.4"
+mpl-token-metadata = { version = "1.4", features = ["serde-feature"] }
 num_cpus = "1.13.0"
 phf = { version = "0.10", features = ["macros"] }
 ratelimit = "0.4.4"

--- a/src/collections/items.rs
+++ b/src/collections/items.rs
@@ -155,7 +155,7 @@ async fn get_mint_collection<'a>(
     let mint_pubkey = Pubkey::from_str(&mint)?;
     let metadata_pubkey = derive_metadata_pda(&mint_pubkey);
     let data = client.get_account_data(&metadata_pubkey).await?;
-    let md = Metadata::deserialize(&mut data.as_slice())?;
+    let md = <Metadata as BorshDeserialize>::deserialize(&mut data.as_slice())?;
 
     Ok((mint, md.collection))
 }

--- a/src/collections/methods.rs
+++ b/src/collections/methods.rs
@@ -36,7 +36,8 @@ pub fn set_and_verify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata = Metadata::deserialize(&mut collection_md_account.as_slice())?;
+    let collection_metadata =
+        <Metadata as BorshDeserialize>::deserialize(&mut collection_md_account.as_slice())?;
 
     let set_and_verify_ix = if collection_metadata.collection_details.is_some() {
         set_and_verify_sized_collection_item(
@@ -90,7 +91,8 @@ pub fn unverify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata = Metadata::deserialize(&mut collection_md_account.as_slice())?;
+    let collection_metadata =
+        <Metadata as BorshDeserialize>::deserialize(&mut collection_md_account.as_slice())?;
 
     // Choose which handler to use based on if collection is sized or not.
     let unverify_collection_ix = if collection_metadata.collection_details.is_some() {
@@ -142,7 +144,8 @@ pub fn verify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata = Metadata::deserialize(&mut collection_md_account.as_slice())?;
+    let collection_metadata =
+        <Metadata as BorshDeserialize>::deserialize(&mut collection_md_account.as_slice())?;
 
     // Choose which handler to use based on if collection is sized or not.
     let verify_collection_ix = if collection_metadata.collection_details.is_some() {

--- a/src/collections/migrate.rs
+++ b/src/collections/migrate.rs
@@ -114,8 +114,9 @@ async fn set_and_verify(
         .get_account_data(&collection_md_pubkey)
         .await
         .map_err(|e| MigrateError::MigrationFailed(nft_mint.clone(), e.to_string()))?;
-    let collection_metadata = Metadata::deserialize(&mut collection_md_account.as_slice())
-        .map_err(|e| MigrateError::MigrationFailed(nft_mint.clone(), e.to_string()))?;
+    let collection_metadata =
+        <Metadata as BorshDeserialize>::deserialize(&mut collection_md_account.as_slice())
+            .map_err(|e| MigrateError::MigrationFailed(nft_mint.clone(), e.to_string()))?;
 
     let set_and_verify_ix = if collection_metadata.collection_details.is_some() {
         set_and_verify_sized_collection_item(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -40,3 +40,5 @@ lazy_static! {
             .copied()
             .collect();
 }
+
+pub const MINT_LAYOUT: u64 = 82;

--- a/src/create/methods.rs
+++ b/src/create/methods.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+pub struct CreateMetadataArgs {
+    pub client: RpcClient,
+    pub keypair: Option<String>,
+    pub mint: String,
+    pub metadata: String,
+    pub immutable: bool,
+}
+
+pub fn create_metadata(args: CreateMetadataArgs) -> Result<()> {
+    let mint_pubkey = Pubkey::from_str(&args.mint)?;
+    let metadata_pubkey = derive_metadata_pda(&mint_pubkey);
+
+    let solana_opts = parse_solana_config();
+    let keypair = parse_keypair(args.keypair, solana_opts);
+
+    let f = File::open(args.metadata)?;
+    let data: Data = serde_json::from_reader(f)?;
+
+    let ix = create_metadata_accounts_v3(
+        METADATA_PROGRAM_ID,
+        metadata_pubkey,
+        mint_pubkey,
+        keypair.pubkey(),
+        keypair.pubkey(),
+        keypair.pubkey(),
+        data.name,
+        data.symbol,
+        data.uri,
+        data.creators,
+        data.seller_fee_basis_points,
+        true,
+        !args.immutable,
+        None,
+        None,
+        None,
+    );
+
+    let instructions = vec![ix];
+
+    let sig = send_and_confirm_transaction(&args.client, keypair, &instructions)?;
+
+    println!("Signature: {}", sig);
+
+    Ok(())
+}
+
+pub struct CreateFungibleArgs {
+    pub client: RpcClient,
+    pub keypair: Option<String>,
+    pub metadata: String,
+    pub decimals: u8,
+    pub initial_supply: Option<u64>,
+    pub immutable: bool,
+}
+
+#[derive(Deserialize)]
+pub struct FungibleFields {
+    pub name: String,
+    pub symbol: String,
+    pub uri: String,
+}
+
+pub fn create_fungible(args: CreateFungibleArgs) -> Result<()> {
+    let solana_opts = parse_solana_config();
+    let keypair = parse_keypair(args.keypair, solana_opts);
+
+    let f = File::open(args.metadata)?;
+    let data: FungibleFields = serde_json::from_reader(f)?;
+
+    let mint = Keypair::new();
+    let metadata_pubkey = derive_metadata_pda(&mint.pubkey());
+
+    let mut instructions = Vec::new();
+
+    // Allocate memory for the account
+    let min_rent = args
+        .client
+        .get_minimum_balance_for_rent_exemption(MINT_LAYOUT as usize)?;
+
+    // Create mint account
+    let create_mint_account_ix = create_account(
+        &keypair.pubkey(),
+        &mint.pubkey(),
+        min_rent,
+        MINT_LAYOUT,
+        &TOKEN_PROGRAM_ID,
+    );
+    instructions.push(create_mint_account_ix);
+
+    // Initalize mint ix
+    let init_mint_ix = initialize_mint(
+        &TOKEN_PROGRAM_ID,
+        &mint.pubkey(),
+        &keypair.pubkey(),
+        Some(&keypair.pubkey()),
+        0,
+    )?;
+    instructions.push(init_mint_ix);
+
+    // Derive associated token account
+    let assoc = get_associated_token_address(&keypair.pubkey(), &mint.pubkey());
+
+    // Create associated account instruction
+    let create_assoc_account_ix =
+        create_associated_token_account(&keypair.pubkey(), &keypair.pubkey(), &mint.pubkey());
+    instructions.push(create_assoc_account_ix);
+
+    if let Some(initial_supply) = args.initial_supply {
+        // Mint to instruction
+        let mint_to_ix = mint_to(
+            &TOKEN_PROGRAM_ID,
+            &mint.pubkey(),
+            &assoc,
+            &keypair.pubkey(),
+            &[],
+            initial_supply,
+        )?;
+        instructions.push(mint_to_ix);
+    }
+
+    let metadata_ix = create_metadata_accounts_v3(
+        METADATA_PROGRAM_ID,
+        metadata_pubkey,
+        mint.pubkey(),
+        keypair.pubkey(),
+        keypair.pubkey(),
+        keypair.pubkey(),
+        data.name,
+        data.symbol,
+        data.uri,
+        None, // Fungible does not have creators
+        0,    // Fungible does not have royalties
+        true,
+        !args.immutable,
+        None,
+        None,
+        None,
+    );
+    instructions.push(metadata_ix);
+
+    let recent_blockhash = args.client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&keypair.pubkey()),
+        &[&keypair, &mint],
+        recent_blockhash,
+    );
+
+    // Send tx with retries.
+    let res = retry(
+        Exponential::from_millis_with_factor(250, 2.0).take(3),
+        || args.client.send_and_confirm_transaction(&tx),
+    );
+
+    let sig = res?;
+    println!("Signature: {sig}");
+    println!("Mint: {}", mint.pubkey());
+    println!("Metadata: {}", metadata_pubkey);
+
+    Ok(())
+}

--- a/src/create/methods.rs
+++ b/src/create/methods.rs
@@ -51,7 +51,7 @@ pub struct CreateFungibleArgs {
     pub keypair: Option<String>,
     pub metadata: String,
     pub decimals: u8,
-    pub initial_supply: Option<u64>,
+    pub initial_supply: Option<f64>,
     pub immutable: bool,
 }
 
@@ -95,7 +95,7 @@ pub fn create_fungible(args: CreateFungibleArgs) -> Result<()> {
         &mint.pubkey(),
         &keypair.pubkey(),
         Some(&keypair.pubkey()),
-        0,
+        args.decimals,
     )?;
     instructions.push(init_mint_ix);
 
@@ -108,6 +108,9 @@ pub fn create_fungible(args: CreateFungibleArgs) -> Result<()> {
     instructions.push(create_assoc_account_ix);
 
     if let Some(initial_supply) = args.initial_supply {
+        // Convert float to native token units
+        let supply = (initial_supply * 10_f64.powi(args.decimals as i32)) as u64;
+
         // Mint to instruction
         let mint_to_ix = mint_to(
             &TOKEN_PROGRAM_ID,
@@ -115,7 +118,7 @@ pub fn create_fungible(args: CreateFungibleArgs) -> Result<()> {
             &assoc,
             &keypair.pubkey(),
             &[],
-            initial_supply,
+            supply,
         )?;
         instructions.push(mint_to_ix);
     }

--- a/src/create/mod.rs
+++ b/src/create/mod.rs
@@ -1,0 +1,29 @@
+pub mod methods;
+pub use methods::*;
+
+use crate::utils::send_and_confirm_transaction;
+use anyhow::Result;
+use metaboss_lib::derive::derive_metadata_pda;
+use mpl_token_metadata::{
+    instruction::create_metadata_accounts_v3, state::Data, ID as METADATA_PROGRAM_ID,
+};
+use retry::{delay::Exponential, retry};
+use serde::Deserialize;
+use solana_client::rpc_client::RpcClient;
+use solana_program::pubkey::Pubkey;
+use solana_sdk::{
+    signature::Keypair, signer::Signer, system_instruction::create_account,
+    transaction::Transaction,
+};
+use spl_associated_token_account::{
+    get_associated_token_address, instruction::create_associated_token_account,
+};
+use spl_token::{
+    instruction::{initialize_mint, mint_to},
+    ID as TOKEN_PROGRAM_ID,
+};
+use std::fs::File;
+use std::str::FromStr;
+
+use crate::constants::*;
+use crate::parse::{parse_keypair, parse_solana_config};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod burn;
 pub mod cache;
 pub mod collections;
 pub mod constants;
+pub mod create;
 pub mod data;
 pub mod decode;
 pub mod derive;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ async fn main() -> Result<()> {
             collections_subcommands,
         } => process_collections(client, async_client, collections_subcommands).await?,
         Command::Burn { burn_subcommands } => process_burn(client, burn_subcommands).await?,
+        Command::Create { create_subcommands } => process_create(client, create_subcommands)?,
         Command::Decode { decode_subcommands } => process_decode(&client, decode_subcommands)?,
         Command::Derive { derive_subcommands } => process_derive(derive_subcommands),
         Command::Find { find_subcommands } => process_find(&client, find_subcommands)?,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -179,7 +179,7 @@ pub enum CreateSubcommands {
 
         /// Mint this amount to your keypair.
         #[structopt(short, long)]
-        initial_supply: Option<u64>,
+        initial_supply: Option<f64>,
 
         /// Create metadata account as immutable.
         #[structopt(long)]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -49,6 +49,12 @@ pub enum Command {
         #[structopt(subcommand)]
         burn_subcommands: BurnSubcommands,
     },
+    /// Create accounts
+    #[structopt(name = "create")]
+    Create {
+        #[structopt(subcommand)]
+        create_subcommands: CreateSubcommands,
+    },
     /// Decode on-chain data into JSON format
     #[structopt(name = "decode")]
     Decode {
@@ -133,6 +139,51 @@ pub enum BurnSubcommands {
         /// Maximum retries: retry failed items up to this many times.
         #[structopt(long, default_value = "1")]
         retries: u8,
+    },
+}
+
+#[derive(Debug, StructOpt)]
+pub enum CreateSubcommands {
+    /// Create a metadata account for an existing SPL token mint.
+    Metadata {
+        /// Path to the update authority keypair file
+        #[structopt(short, long)]
+        keypair: Option<String>,
+
+        /// Mint account
+        #[structopt(short = "a", long)]
+        mint: String,
+
+        /// Path to JSON file of metadata
+        #[structopt(short, long)]
+        metadata: String,
+
+        /// Create metadata account as immutable.
+        #[structopt(long)]
+        immutable: bool,
+    },
+
+    /// Create a new SPL Token mint and metadata account.
+    Fungible {
+        /// Path to the update authority keypair file
+        #[structopt(short, long)]
+        keypair: Option<String>,
+
+        /// Path to JSON file of metadata
+        #[structopt(short, long)]
+        metadata: String,
+
+        /// SPL token decmials, defaults to 0.
+        #[structopt(short, long, default_value = "0")]
+        decimals: u8,
+
+        /// Mint this amount to your keypair.
+        #[structopt(short, long)]
+        initial_supply: Option<u64>,
+
+        /// Create metadata account as immutable.
+        #[structopt(long)]
+        immutable: bool,
     },
 }
 

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -7,6 +7,7 @@ use crate::collections::{
     revoke_delegate, set_and_verify_nft_collection, set_size, unverify_nft_collection,
     verify_nft_collection, MigrateArgs,
 };
+use crate::create::{create_fungible, create_metadata, CreateFungibleArgs, CreateMetadataArgs};
 use crate::decode::{decode_master_edition, decode_metadata};
 use crate::derive::{get_cmv2_pda, get_edition_pda, get_generic_pda, get_metadata_pda};
 use crate::find::find_missing_editions_process;
@@ -183,6 +184,37 @@ pub async fn process_burn(client: RpcClient, commands: BurnSubcommands) -> Resul
             })
             .await
         }
+    }
+}
+
+pub fn process_create(client: RpcClient, commands: CreateSubcommands) -> Result<()> {
+    match commands {
+        CreateSubcommands::Metadata {
+            keypair,
+            mint,
+            metadata,
+            immutable,
+        } => create_metadata(CreateMetadataArgs {
+            client,
+            keypair,
+            mint,
+            metadata,
+            immutable,
+        }),
+        CreateSubcommands::Fungible {
+            keypair,
+            metadata,
+            decimals,
+            initial_supply,
+            immutable,
+        } => create_fungible(CreateFungibleArgs {
+            client,
+            keypair,
+            metadata,
+            decimals,
+            initial_supply,
+            immutable,
+        }),
     }
 }
 


### PR DESCRIPTION
Adds the `create` subcommand with:

* `create metadata` for decorating an existing SPL mint with a Metaplex metadata account
* `create fungible` for creating a new SPL token and metadata account

![cilantro@pop-os: ~_002](https://user-images.githubusercontent.com/1684605/191670621-da8ae0ef-4ee2-4df7-85bd-d3f551e056aa.png)

![cilantro@pop-os: ~_004](https://user-images.githubusercontent.com/1684605/191670632-69d84617-7614-44cc-a824-dc74004dc4f1.png)
