### PR TITLE
allow --v3 snapshot and signing

### DIFF
--- a/src/collections/migrate.rs
+++ b/src/collections/migrate.rs
@@ -225,7 +225,15 @@ pub async fn migrate_collection(args: MigrateArgs) -> AnyResult<()> {
 
     let mut mint_accounts = if let Some(candy_machine_id) = args.candy_machine_id {
         println!("Using candy machine id to fetch mint list. . .");
-        get_mint_accounts(&args.client, &Some(candy_machine_id), 0, None, false, true)?
+        get_mint_accounts(
+            &args.client,
+            &Some(candy_machine_id),
+            0,
+            None,
+            false,
+            true,
+            false,
+        )?
     } else if let Some(mint_list) = args.mint_list {
         let f = File::open(mint_list)?;
         serde_json::from_reader(f)?

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -51,6 +51,12 @@ pub fn get_cmv2_pda(candy_machine_id: String) {
     println!("{}", derive_cmv2_pda(&pubkey));
 }
 
+pub fn get_cmv3_pda(candy_machine_id: String) {
+    let pubkey =
+        Pubkey::from_str(&candy_machine_id).expect("Failed to parse pubkey from candy_machine_id!");
+    println!("{}", derive_cmv3_pda(&pubkey));
+}
+
 fn derive_generic_pda(seeds: Vec<&[u8]>, program_id: Pubkey) -> Pubkey {
     let (pda, _) = Pubkey::find_program_address(&seeds, &program_id);
     pda
@@ -107,6 +113,16 @@ pub fn derive_cmv2_pda(pubkey: &Pubkey) -> Pubkey {
     let seeds = &["candy_machine".as_bytes(), pubkey.as_ref()];
 
     let (pda, _) = Pubkey::find_program_address(seeds, &cmv2_pubkey);
+    pda
+}
+
+pub fn derive_cmv3_pda(pubkey: &Pubkey) -> Pubkey {
+    let cmv3_pubkey = Pubkey::from_str("CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR")
+        .expect("Failed to parse pubkey from candy machine program id!");
+
+    let seeds = &["candy_machine".as_bytes(), pubkey.as_ref()];
+
+    let (pda, _) = Pubkey::find_program_address(seeds, &cmv3_pubkey);
     pda
 }
 
@@ -184,5 +200,14 @@ mod tests {
         let expected_pda =
             Pubkey::from_str("8J9W44AfgWFMSwE4iYyZMNCWV9mKqovS5YHiVoKuuA2b").unwrap();
         assert_eq!(derive_cmv2_pda(&candy_machine_pubkey), expected_pda);
+    }
+
+    #[test]
+    fn test_derive_cmv3_pda() {
+        let candy_machine_pubkey =
+            Pubkey::from_str("2YkBXpx61ziscLL4aAdXYnjCsoHK5TF9rF9AgkhhLJAX").unwrap();
+        let expected_pda =
+            Pubkey::from_str("Ei45DbGouAM7NkN5Rk22ep415vbGrbVPEDG9tRfoHb5B").unwrap();
+        assert_eq!(derive_cmv3_pda(&candy_machine_pubkey), expected_pda);
     }
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -856,6 +856,10 @@ pub enum SignSubcommands {
         #[structopt(long = "v2")]
         v2: bool,
 
+        /// Candy machine v3 id
+        #[structopt(long = "v3")]
+        v3: bool,
+
         /// Path to JSON file with list of mint accounts to sign
         #[structopt(short, long)]
         mint_accounts_file: Option<String>,
@@ -871,7 +875,7 @@ pub enum SnapshotSubcommands {
         #[structopt(short, long)]
         update_authority: Option<String>,
 
-        /// Creator to filter accounts by (for CM v2 use --v2 if candy_machine account is passed)
+        /// Creator to filter accounts by (for CM v2 use --v2, for CM v3 use --v3 if candy_machine account is passed)
         #[structopt(short, long)]
         creator: Option<String>,
 
@@ -932,7 +936,7 @@ pub enum SnapshotSubcommands {
     /// Snapshot all mint accounts for a given candy_machine_id / creatoro or update authority
     #[structopt(name = "mints")]
     Mints {
-        /// Creator to filter accounts by (for CM v2 use --v2 if candy_machine account is passed)
+        /// Creator to filter accounts by (for CM v2 use --v2, for CM v3 use --v3 if candy_machine account is passed)
         #[structopt(short, long)]
         creator: Option<String>,
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -883,6 +883,10 @@ pub enum SnapshotSubcommands {
         #[structopt(long = "v2")]
         v2: bool,
 
+        /// Candy machine v3 id
+        #[structopt(long = "v3")]
+        v3: bool,
+
         /// Path to JSON file with list of mint accounts to sign
         #[structopt(short, long)]
         mint_accounts_file: Option<String>,
@@ -943,6 +947,10 @@ pub enum SnapshotSubcommands {
         /// Candy machine v2 id
         #[structopt(long = "v2")]
         v2: bool,
+
+        /// Candy machine v3 id
+        #[structopt(long = "v3")]
+        v3: bool,
 
         /// Allow fetching items with unverified creator or update authority.
         #[structopt(long)]

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -470,6 +470,7 @@ pub async fn process_snapshot(client: &RpcClient, commands: SnapshotSubcommands)
             position,
             mint_accounts_file,
             v2,
+            v3,
             allow_unverified,
             output,
         } => snapshot_holders(
@@ -480,6 +481,7 @@ pub async fn process_snapshot(client: &RpcClient, commands: SnapshotSubcommands)
                 position,
                 mint_accounts_file,
                 v2,
+                v3,
                 allow_unverified,
                 output,
             },
@@ -499,6 +501,7 @@ pub async fn process_snapshot(client: &RpcClient, commands: SnapshotSubcommands)
             position,
             update_authority,
             v2,
+            v3,
             allow_unverified,
             output,
         } => snapshot_mints(
@@ -508,6 +511,7 @@ pub async fn process_snapshot(client: &RpcClient, commands: SnapshotSubcommands)
                 position,
                 update_authority,
                 v2,
+                v3,
                 allow_unverified,
                 output,
             },

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -457,8 +457,17 @@ pub fn process_sign(client: &RpcClient, commands: SignSubcommands) -> Result<()>
             creator,
             position,
             v2,
+            v3,
             mint_accounts_file,
-        } => sign_all(client, keypair, &creator, position, v2, mint_accounts_file),
+        } => sign_all(
+            client,
+            keypair,
+            &creator,
+            position,
+            v2,
+            v3,
+            mint_accounts_file,
+        ),
     }
 }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use crate::decode::get_metadata_pda;
-use crate::derive::derive_cmv2_pda;
+use crate::derive::{derive_cmv2_pda, derive_cmv3_pda};
 use crate::limiter::create_default_rate_limiter;
 use crate::parse::{is_only_one_option, parse_keypair};
 use crate::snapshot::get_cm_creator_accounts;
@@ -54,6 +54,7 @@ pub fn sign_all(
     creator: &Option<String>,
     position: usize,
     v2: bool,
+    v3: bool,
     mint_accounts_file: Option<String>,
 ) -> Result<()> {
     let solana_opts = parse_solana_config();
@@ -66,13 +67,21 @@ pub fn sign_all(
     }
 
     if let Some(creator) = creator {
+        let creator_pubkey =
+            Pubkey::from_str(creator).expect("Failed to parse pubkey from creator!");
         if v2 {
-            let creator_pubkey =
-                Pubkey::from_str(creator).expect("Failed to parse pubkey from creator!");
             let cmv2_creator = derive_cmv2_pda(&creator_pubkey);
             sign_candy_machine_accounts(
                 client,
                 &cmv2_creator.to_string(),
+                creator_keypair,
+                position,
+            )?
+        } else if v3 {
+            let cmv3_creator = derive_cmv3_pda(&creator_pubkey);
+            sign_candy_machine_accounts(
+                client,
+                &cmv3_creator.to_string(),
                 creator_keypair,
                 position,
             )?

--- a/src/snapshot/data.rs
+++ b/src/snapshot/data.rs
@@ -34,6 +34,7 @@ pub struct SnapshotMintsArgs {
     pub position: usize,
     pub update_authority: Option<String>,
     pub v2: bool,
+    pub v3: bool,
     pub allow_unverified: bool,
     pub output: String,
 }
@@ -44,6 +45,7 @@ pub struct SnapshotHoldersArgs {
     pub update_authority: Option<String>,
     pub mint_accounts_file: Option<String>,
     pub v2: bool,
+    pub v3: bool,
     pub allow_unverified: bool,
     pub output: String,
 }


### PR DESCRIPTION
Currently the snapshot and sign commands only support candy machine v1 and v2. This PR adds the possibility to use a --v3 flag to derive it correctly.