### PR TITLE
fix: typo in TokenStandard struct

### DIFF
--- a/src/collections/data.rs
+++ b/src/collections/data.rs
@@ -29,7 +29,7 @@ pub enum TokenStandard {
     NonFungible,
     Fungible,
     FungibleAsset,
-    NonfungibleEdition,
+    NonFungibleEdition,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/theindexio/data.rs
+++ b/src/theindexio/data.rs
@@ -30,7 +30,7 @@ pub enum TokenStandard {
     NonFungible,
     Fungible,
     FungibleAsset,
-    NonfungibleEdition,
+    NonFungibleEdition,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## tl;dr

- [x] Fixes a typo in the `TokenStandard` struct

## Description

I noticed this issue after trying to fetch collection items using metaboss:

```bash
❯ metaboss collections get-items --collection-mint 9jnJWH9F9t1xAgw5RGwswVKY4GvY2RXhzLSJgpBAhoaR --api-key some-indexio-api-key
[=   ] Fetching data from TheIndex.io. . .
Error: error decoding response body: unknown variant `NonFungibleEdition`, expected one of `NonFungible`, `Fungible`, `FungibleAsset`, `NonfungibleEdition` at line 1 column 5002805

Caused by:
    unknown variant `NonFungibleEdition`, expected one of `NonFungible`, `Fungible`, `FungibleAsset`, `NonfungibleEdition` at line 1 column 5002805
```