### PR TITLE
Fix typos

### DIFF
--- a/src/burn.rs
+++ b/src/burn.rs
@@ -48,7 +48,7 @@ pub async fn burn_one(
 
     let sig = burn(args).await?;
 
-    println!("TxId: {sig}");
+    println!("Tx sig: {sig}");
 
     Ok(())
 }
@@ -76,7 +76,7 @@ pub async fn burn_print_one(
 
     let sig = burn_print(args).await?;
 
-    println!("TxId: {sig}");
+    println!("Tx sig: {sig}");
 
     Ok(())
 }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -324,8 +324,8 @@ pub fn mint_one<P: AsRef<Path>>(
         max_editions,
         sized,
     )?;
-    info!("Tx id: {:?}\nMint account: {:?}", &tx_id, &mint_account);
-    let message = format!("Tx id: {:?}\nMint account: {:?}", &tx_id, &mint_account,);
+    info!("Tx sig: {:?}\nMint account: {:?}", &tx_id, &mint_account);
+    let message = format!("Tx sig: {:?}\nMint account: {:?}", &tx_id, &mint_account,);
     println!("{message}");
     if sign {
         //TODO: Error handling

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1142,7 +1142,7 @@ pub enum UpdateSubcommands {
         #[structopt(short = "a", long)]
         mint: String,
     },
-    /// REmove the rule set from a batch of pNFTs.
+    /// Remove the rule set from a batch of pNFTs.
     ClearRuleSetAll {
         /// Path to the creator's keypair file
         #[structopt(short, long)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,7 +41,7 @@ pub fn send_and_confirm_transaction(
 
     let sig = res?;
 
-    println!("TxId: {sig}");
+    println!("Tx sig: {sig}");
     Ok(sig.to_string())
 }
 


### PR DESCRIPTION
fix small typo & use consistent messages when printing tx sigs; parsing some logs I've seen signatures preceded by "Tx id", "TxId" or "Tx sig"