### PR TITLE
use safe_deserialize; allow unverifying w/ burned parent

### DIFF
--- a/src/collections/methods.rs
+++ b/src/collections/methods.rs
@@ -36,7 +36,7 @@ pub fn set_and_verify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata = Metadata::safe_deserialize(&mut collection_md_account.as_slice())?;
+    let collection_metadata = Metadata::safe_deserialize(collection_md_account.as_slice())?;
 
     let set_and_verify_ix = if collection_metadata.collection_details.is_some() {
         set_and_verify_sized_collection_item(
@@ -103,8 +103,7 @@ pub fn unverify_nft_collection(
             collection_authority_record,
         )
     } else {
-        let collection_metadata =
-            Metadata::safe_deserialize(&mut collection_md_account.as_slice())?;
+        let collection_metadata = Metadata::safe_deserialize(collection_md_account.as_slice())?;
 
         // Choose which handler to use based on if collection is sized or not.
         if collection_metadata.collection_details.is_some() {
@@ -157,7 +156,7 @@ pub fn verify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata = Metadata::safe_deserialize(&mut collection_md_account.as_slice())?;
+    let collection_metadata = Metadata::safe_deserialize(collection_md_account.as_slice())?;
 
     // Choose which handler to use based on if collection is sized or not.
     let verify_collection_ix = if collection_metadata.collection_details.is_some() {

--- a/src/collections/methods.rs
+++ b/src/collections/methods.rs
@@ -5,11 +5,11 @@ use crate::{
     parse::parse_solana_config,
     utils::send_and_confirm_transaction,
 };
-use borsh::BorshDeserialize;
 use mpl_token_metadata::instruction::{
     set_and_verify_sized_collection_item, set_collection_size, unverify_sized_collection_item,
     verify_sized_collection_item,
 };
+use mpl_token_metadata::state::TokenMetadataAccount;
 
 pub const OPEN_FILES_LIMIT: usize = 1024;
 
@@ -36,8 +36,7 @@ pub fn set_and_verify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata =
-        <Metadata as BorshDeserialize>::deserialize(&mut collection_md_account.as_slice())?;
+    let collection_metadata = Metadata::safe_deserialize(&mut collection_md_account.as_slice())?;
 
     let set_and_verify_ix = if collection_metadata.collection_details.is_some() {
         set_and_verify_sized_collection_item(
@@ -91,22 +90,9 @@ pub fn unverify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata =
-        <Metadata as BorshDeserialize>::deserialize(&mut collection_md_account.as_slice())?;
 
-    // Choose which handler to use based on if collection is sized or not.
-    let unverify_collection_ix = if collection_metadata.collection_details.is_some() {
-        unverify_sized_collection_item(
-            metadata_program_id(),
-            nft_metadata,
-            keypair.pubkey(),
-            keypair.pubkey(),
-            collection_pubkey,
-            collection_md_pubkey,
-            collection_edition_pubkey,
-            collection_authority_record,
-        )
-    } else {
+    // If the collection account is empty, it was burned and we can use either handler.
+    let unverify_collection_ix = if collection_md_account.is_empty() {
         unverify_collection(
             metadata_program_id(),
             nft_metadata,
@@ -116,6 +102,33 @@ pub fn unverify_nft_collection(
             collection_edition_pubkey,
             collection_authority_record,
         )
+    } else {
+        let collection_metadata =
+            Metadata::safe_deserialize(&mut collection_md_account.as_slice())?;
+
+        // Choose which handler to use based on if collection is sized or not.
+        if collection_metadata.collection_details.is_some() {
+            unverify_sized_collection_item(
+                metadata_program_id(),
+                nft_metadata,
+                keypair.pubkey(),
+                keypair.pubkey(),
+                collection_pubkey,
+                collection_md_pubkey,
+                collection_edition_pubkey,
+                collection_authority_record,
+            )
+        } else {
+            unverify_collection(
+                metadata_program_id(),
+                nft_metadata,
+                keypair.pubkey(),
+                collection_pubkey,
+                collection_md_pubkey,
+                collection_edition_pubkey,
+                collection_authority_record,
+            )
+        }
     };
 
     send_and_confirm_transaction(&client, keypair, &[unverify_collection_ix])?;
@@ -144,8 +157,7 @@ pub fn verify_nft_collection(
 
     // Is it a sized collection?
     let collection_md_account = client.get_account_data(&collection_md_pubkey)?;
-    let collection_metadata =
-        <Metadata as BorshDeserialize>::deserialize(&mut collection_md_account.as_slice())?;
+    let collection_metadata = Metadata::safe_deserialize(&mut collection_md_account.as_slice())?;
 
     // Choose which handler to use based on if collection is sized or not.
     let verify_collection_ix = if collection_metadata.collection_details.is_some() {


### PR DESCRIPTION
Merge after Token Metadata fix is deployed to mainnet. 