### PR TITLE
Add receiver account transfer option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "metaboss_lib"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac6fc7596d013ea3b2f64c90f9617fbcf5f600b42194557ede18707e152b082"
+checksum = "0ae52c214cb5afabb0b10fbdda6b8ad942f3b5dca03a14c75a8d2ff37cd76ad1"
 dependencies = [
  "anyhow",
  "mpl-token-metadata",
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-auth-rules"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69803fbfbc4bb0327de86f49d2639692c7c60276cb87d6cced84bb8189f2000"
+checksum = "24dcb2b0ec0e9246f6f035e0336ba3359c21f6928dfd90281999e2c8e8ab53eb"
 dependencies = [
  "borsh",
  "mpl-token-metadata-context-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,11 +1874,12 @@ dependencies = [
 
 [[package]]
 name = "metaboss_lib"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae52c214cb5afabb0b10fbdda6b8ad942f3b5dca03a14c75a8d2ff37cd76ad1"
+checksum = "e96106e42c036507fcadb13e52650cdc4464a984107d3daa6cbdb77e66dd0943"
 dependencies = [
  "anyhow",
+ "mpl-token-auth-rules",
  "mpl-token-metadata",
  "retry",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 lazy_static = "1.4.0"
 log = "0.4.17"
-metaboss_lib = "0.8.0"
+metaboss_lib = "0.8.1"
 mpl-token-metadata = { version = "1.9.0", features = [ "no-entrypoint", "serde-feature"] }
 num_cpus = "1.13.1"
 phf = { version = "0.10", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 lazy_static = "1.4.0"
 log = "0.4.17"
-metaboss_lib = "0.7.1"
+metaboss_lib = "0.8.0"
 mpl-token-metadata = { version = "1.9.0", features = [ "no-entrypoint", "serde-feature"] }
 num_cpus = "1.13.1"
 phf = { version = "0.10", features = ["macros"] }

--- a/src/collections/migrate.rs
+++ b/src/collections/migrate.rs
@@ -157,7 +157,6 @@ fn set_and_verify(
             payer: None,
             token: None::<String>,
             delegate_record: None::<String>, // Not supported yet in update.
-            current_rule_set: None::<String>,
             update_args,
         },
     )

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1572,6 +1572,10 @@ pub enum TransferSubcommands {
         /// Amount of tokens to transfer, for NonFungible types this must be 1.
         #[structopt(long, default_value = "1")]
         amount: u64,
+
+        /// Receiver token account, if not provided an ATA will be created.
+        #[structopt(long)]
+        receiver_account: Option<String>,
     },
 }
 

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -809,7 +809,8 @@ pub fn process_transfer(client: RpcClient, commands: TransferSubcommands) -> Res
             receiver,
             mint,
             amount,
-        } => process_transfer_asset(&client, keypair, receiver, mint, amount),
+            receiver_account,
+        } => process_transfer_asset(&client, keypair, receiver, receiver_account, mint, amount),
     }
 }
 

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -13,6 +13,7 @@ pub fn process_transfer_asset(
     client: &RpcClient,
     keypair_path: Option<String>,
     receiver: String,
+    receiver_account: Option<String>,
     mint: String,
     amount: u64,
 ) -> Result<()> {
@@ -23,7 +24,11 @@ pub fn process_transfer_asset(
     let mint = Pubkey::from_str(&mint)?;
 
     let source_ata = get_associated_token_address(&authority.pubkey(), &mint);
-    let destination_ata = get_associated_token_address(&receiver, &mint);
+    let destination_token = if let Some(account) = receiver_account {
+        Pubkey::from_str(&account)?
+    } else {
+        get_associated_token_address(&receiver, &mint)
+    };
 
     let args = TransferAssetArgs::V1 {
         payer: None,
@@ -32,7 +37,7 @@ pub fn process_transfer_asset(
         source_owner: authority.pubkey(),
         source_token: source_ata,
         destination_owner: receiver,
-        destination_token: destination_ata,
+        destination_token,
         amount,
         authorization_data: None,
     };

--- a/src/update/creator.rs
+++ b/src/update/creator.rs
@@ -13,7 +13,7 @@ pub struct UpdateCreatorArgs {
 }
 
 pub async fn update_creator(args: UpdateCreatorArgs) -> Result<Signature, ActionError> {
-    let (mut current_md, token, current_rule_set) =
+    let (mut current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -62,7 +62,6 @@ pub async fn update_creator(args: UpdateCreatorArgs) -> Result<Signature, Action
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/data.rs
+++ b/src/update/data.rs
@@ -24,7 +24,7 @@ pub struct UpdateDataArgs {
 }
 
 pub async fn update_data(args: UpdateDataArgs) -> Result<Signature, ActionError> {
-    let (_current_md, token, current_rule_set) =
+    let (_current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -43,7 +43,6 @@ pub async fn update_data(args: UpdateDataArgs) -> Result<Signature, ActionError>
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/immutable.rs
+++ b/src/update/immutable.rs
@@ -18,7 +18,7 @@ pub struct SetImmutableAllArgs {
 }
 
 pub async fn set_immutable(args: SetImmutableArgs) -> Result<Signature, ActionError> {
-    let (_current_md, token, current_rule_set) =
+    let (_current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -39,7 +39,6 @@ pub async fn set_immutable(args: SetImmutableArgs) -> Result<Signature, ActionEr
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/name.rs
+++ b/src/update/name.rs
@@ -8,7 +8,7 @@ pub struct UpdateNameArgs {
 }
 
 pub async fn update_name(args: UpdateNameArgs) -> Result<Signature, ActionError> {
-    let (mut current_md, token, current_rule_set) =
+    let (mut current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -27,7 +27,6 @@ pub async fn update_name(args: UpdateNameArgs) -> Result<Signature, ActionError>
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/primary_sale_happened.rs
+++ b/src/update/primary_sale_happened.rs
@@ -20,7 +20,7 @@ pub struct SetPrimarySaleHappenedArgs {
 pub async fn set_primary_sale_happened(
     args: SetPrimarySaleHappenedArgs,
 ) -> Result<Signature, ActionError> {
-    let (_, token, current_rule_set) = update_asset_preface(&args.client, &args.mint_account)
+    let (_, token, _current_rule_set) = update_asset_preface(&args.client, &args.mint_account)
         .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
     // Token Metadata UpdateArgs enum.
@@ -39,7 +39,6 @@ pub async fn set_primary_sale_happened(
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/rule_set.rs
+++ b/src/update/rule_set.rs
@@ -59,12 +59,12 @@ pub async fn update_rule_set(args: UpdateRuleSetArgs) -> Result<Signature, Actio
 
     *rule_set = RuleSetToggle::Set(new_rule_set);
 
-    let current_rule_set = if let Some(ProgrammableConfig::V1 { rule_set }) = md.programmable_config
-    {
-        rule_set
-    } else {
-        None
-    };
+    let _current_rule_set =
+        if let Some(ProgrammableConfig::V1 { rule_set }) = md.programmable_config {
+            rule_set
+        } else {
+            None
+        };
 
     // Metaboss UpdateAssetArgs enum.
     let update_args = UpdateAssetArgs::V1 {
@@ -73,7 +73,6 @@ pub async fn update_rule_set(args: UpdateRuleSetArgs) -> Result<Signature, Actio
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 
@@ -106,12 +105,12 @@ pub async fn clear_rule_set(args: ClearRuleSetArgs) -> Result<Signature, ActionE
 
     *rule_set = RuleSetToggle::Clear;
 
-    let current_rule_set = if let Some(ProgrammableConfig::V1 { rule_set }) = md.programmable_config
-    {
-        rule_set
-    } else {
-        None
-    };
+    let _current_rule_set =
+        if let Some(ProgrammableConfig::V1 { rule_set }) = md.programmable_config {
+            rule_set
+        } else {
+            None
+        };
 
     // Metaboss UpdateAssetArgs enum.
     let update_args = UpdateAssetArgs::V1 {
@@ -120,7 +119,6 @@ pub async fn clear_rule_set(args: ClearRuleSetArgs) -> Result<Signature, ActionE
         mint,
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/seller_fee_basis_points.rs
+++ b/src/update/seller_fee_basis_points.rs
@@ -19,7 +19,7 @@ pub struct UpdateSellerFeeBasisPointsAllArgs {
 }
 
 pub async fn update_sfbp(args: UpdateSellerFeeBasisPointsArgs) -> Result<Signature, ActionError> {
-    let (mut current_md, token, current_rule_set) =
+    let (mut current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -41,7 +41,6 @@ pub async fn update_sfbp(args: UpdateSellerFeeBasisPointsArgs) -> Result<Signatu
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/symbol.rs
+++ b/src/update/symbol.rs
@@ -20,7 +20,7 @@ pub struct UpdateSymbolArgs {
 }
 
 pub async fn update_symbol(args: UpdateSymbolArgs) -> Result<Signature, ActionError> {
-    let (mut current_md, token, current_rule_set) =
+    let (mut current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -39,7 +39,6 @@ pub async fn update_symbol(args: UpdateSymbolArgs) -> Result<Signature, ActionEr
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/update_authority.rs
+++ b/src/update/update_authority.rs
@@ -22,7 +22,7 @@ pub struct SetUpdateAuthorityArgs {
 }
 
 pub async fn set_update_authority(args: SetUpdateAuthorityArgs) -> Result<Signature, ActionError> {
-    let (_current_md, token, current_rule_set) =
+    let (_current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -46,7 +46,6 @@ pub async fn set_update_authority(args: SetUpdateAuthorityArgs) -> Result<Signat
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/uri.rs
+++ b/src/update/uri.rs
@@ -24,7 +24,7 @@ pub struct UpdateUriArgs {
 }
 
 pub async fn update_uri(args: UpdateUriArgs) -> Result<Signature, ActionError> {
-    let (mut current_md, token, current_rule_set) =
+    let (mut current_md, token, _current_rule_set) =
         update_asset_preface(&args.client, &args.mint_account)
             .map_err(|e| ActionError::ActionFailed(args.mint_account.to_string(), e.to_string()))?;
 
@@ -49,7 +49,6 @@ pub async fn update_uri(args: UpdateUriArgs) -> Result<Signature, ActionError> {
         mint: args.mint_account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 

--- a/src/update/uses.rs
+++ b/src/update/uses.rs
@@ -21,9 +21,8 @@ pub fn update_uses_one(args: UsesArgs) -> Result<Signature, ActionError> {
     let solana_opts = parse_solana_config();
     let keypair = parse_keypair(args.keypair, solana_opts);
 
-    let (current_md, token, current_rule_set) =
-        update_asset_preface(&args.client, &args.account)
-            .map_err(|e| ActionError::ActionFailed(args.account.to_string(), e.to_string()))?;
+    let (current_md, token, _current_rule_set) = update_asset_preface(&args.client, &args.account)
+        .map_err(|e| ActionError::ActionFailed(args.account.to_string(), e.to_string()))?;
 
     let use_method = match args.method.to_lowercase().as_str() {
         "burn" => UseMethod::Burn,
@@ -64,7 +63,6 @@ pub fn update_uses_one(args: UsesArgs) -> Result<Signature, ActionError> {
         mint: args.account.clone(),
         token,
         delegate_record: None::<String>, // Not supported yet in update.
-        current_rule_set,
         update_args,
     };
 


### PR DESCRIPTION
This PR adds an option to specify a receiver account on `transfer`. This allows transferring assets to a token (non-ATA) account.