### PR TITLE
allow vanity mints for single mint commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "metaboss_lib"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881ee7b42550cba5827c629f8961d3c93e1b2134c639eedeb7be35cdd2512b65"
+checksum = "d54fe28a88a7ae7bc5f4922a60f58808597cfc5b49365a1eff314caa7ebb80f4"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ indicatif = { version = "0.16.2", features = ["rayon"] }
 jib = "0.4.1"
 lazy_static = "1.4.0"
 log = "0.4.20"
-metaboss_lib = "0.16.1"
+metaboss_lib = "0.17.0"
 mpl-token-metadata = { version = "3.2.3", features = ["serde"] }
 num_cpus = "1.16.0"
 phf = { version = "0.10", features = ["macros"] }

--- a/src/create/methods.rs
+++ b/src/create/methods.rs
@@ -81,7 +81,7 @@ pub struct CreateFungibleArgs {
     pub client: RpcClient,
     pub keypair: Option<String>,
     pub metadata: String,
-    pub mint: Option<String>,
+    pub mint_path: Option<String>,
     pub decimals: u8,
     pub initial_supply: Option<f64>,
     pub immutable: bool,
@@ -112,7 +112,7 @@ pub fn create_fungible(args: CreateFungibleArgs) -> Result<()> {
     let solana_opts = parse_solana_config();
     let keypair = parse_keypair(args.keypair, solana_opts);
 
-    let mint = if let Some(path) = args.mint {
+    let mint = if let Some(path) = args.mint_path {
         read_keypair_file(&path)
             .map_err(|e| anyhow!(format!("Failed to read mint keypair file: {e}")))?
     } else {

--- a/src/create/methods.rs
+++ b/src/create/methods.rs
@@ -81,6 +81,7 @@ pub struct CreateFungibleArgs {
     pub client: RpcClient,
     pub keypair: Option<String>,
     pub metadata: String,
+    pub mint: Option<String>,
     pub decimals: u8,
     pub initial_supply: Option<f64>,
     pub immutable: bool,
@@ -111,7 +112,13 @@ pub fn create_fungible(args: CreateFungibleArgs) -> Result<()> {
     let solana_opts = parse_solana_config();
     let keypair = parse_keypair(args.keypair, solana_opts);
 
-    let mint = Keypair::new();
+    let mint = if let Some(path) = args.mint {
+        read_keypair_file(&path)
+            .map_err(|e| anyhow!(format!("Failed to read mint keypair file: {e}")))?
+    } else {
+        Keypair::new()
+    };
+
     let metadata_pubkey = derive_metadata_pda(&mint.pubkey());
 
     let f = File::open(args.metadata)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
             additional_bytes,
         } => process_extend_program(client, keypair_path, program_address, additional_bytes)?,
         Command::Find { find_subcommands } => process_find(&client, find_subcommands)?,
-        Command::Mint { mint_subcommands } => process_mint(&client, mint_subcommands)?,
+        Command::Mint { mint_subcommands } => process_mint(client, mint_subcommands)?,
         Command::ParseErrors {
             parse_errors_file_subcommands,
         } => process_parse_errors_file(parse_errors_file_subcommands)?,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -319,7 +319,7 @@ pub enum CreateSubcommands {
         #[structopt(short, long)]
         keypair: Option<String>,
 
-        /// Mint account
+        /// Existing mint account created elsewhere
         #[structopt(short = "a", long)]
         mint: String,
 
@@ -344,7 +344,7 @@ pub enum CreateSubcommands {
 
         /// Vanity mint: path to a keypair file to use for the mint address.
         #[structopt(long)]
-        mint: Option<String>,
+        mint_path: Option<String>,
 
         /// SPL token decmials, defaults to 0.
         #[structopt(short, long, default_value = "0")]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -342,6 +342,10 @@ pub enum CreateSubcommands {
         #[structopt(short, long)]
         metadata: String,
 
+        /// Vanity mint: path to a keypair file to use for the mint address.
+        #[structopt(long)]
+        mint: Option<String>,
+
         /// SPL token decmials, defaults to 0.
         #[structopt(short, long, default_value = "0")]
         decimals: u8,
@@ -813,6 +817,10 @@ pub enum MintSubcommands {
         #[structopt(short = "R", long)]
         receiver: Option<String>,
 
+        /// Path to mint keypair file, if minting from existing keypair.
+        #[structopt(short, long)]
+        mint_path: Option<String>,
+
         /// Asset data
         #[structopt(short = "d", long)]
         asset_data: PathBuf,
@@ -840,6 +848,10 @@ pub enum MintSubcommands {
         /// Receiving address, if different from update authority.
         #[structopt(short = "R", long)]
         receiver: Option<String>,
+
+        /// Path to the keypair of the mint account to use for the new NFT
+        #[structopt(long)]
+        mint_path: Option<String>,
 
         /// On-chain formatted metadata for the new NFT
         #[structopt(short = "d", long)]

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -30,7 +30,9 @@ use crate::derive::{
     get_generic_pda, get_metadata_pda, get_token_record_pda,
 };
 use crate::find::find_missing_editions_process;
-use crate::mint::{mint_editions, mint_list, mint_missing_editions, mint_one, process_mint_asset};
+use crate::mint::{
+    mint_editions, mint_list, mint_missing_editions, mint_one, process_mint_asset, MintAssetParams,
+};
 use crate::opt::*;
 use crate::parse::{is_only_one_option, parse_errors_code, parse_errors_file};
 use crate::sign::{sign_all, sign_one};
@@ -323,6 +325,7 @@ pub fn process_create(client: RpcClient, commands: CreateSubcommands) -> Result<
         CreateSubcommands::Fungible {
             keypair,
             metadata,
+            mint,
             decimals,
             initial_supply,
             immutable,
@@ -330,6 +333,7 @@ pub fn process_create(client: RpcClient, commands: CreateSubcommands) -> Result<
             client,
             keypair,
             metadata,
+            mint,
             decimals,
             initial_supply,
             immutable,
@@ -471,27 +475,30 @@ pub fn process_find(client: &RpcClient, commands: FindSubcommands) -> Result<()>
     }
 }
 
-pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()> {
+pub fn process_mint(client: RpcClient, commands: MintSubcommands) -> Result<()> {
     match commands {
         MintSubcommands::Asset {
             keypair,
             receiver,
+            mint_path,
             asset_data,
             amount,
             decimals,
             max_print_edition_supply,
-        } => process_mint_asset(
+        } => process_mint_asset(MintAssetParams {
             client,
-            keypair,
+            keypair_path: keypair,
             receiver,
+            mint_path,
             asset_data,
             decimals,
             amount,
             max_print_edition_supply,
-        ),
+        }),
         MintSubcommands::One {
             keypair,
             receiver,
+            mint_path,
             nft_data_file,
             external_metadata_uri,
             immutable,
@@ -500,7 +507,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             sign,
             sized,
         } => mint_one(
-            client,
+            &client,
             keypair,
             &receiver,
             nft_data_file,
@@ -508,6 +515,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             immutable,
             primary_sale_happened,
             max_editions,
+            mint_path,
             sign,
             sized,
         )
@@ -519,7 +527,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             next_editions,
             specific_editions,
         } => mint_editions(
-            client,
+            &client,
             keypair,
             account,
             &receiver,
@@ -527,7 +535,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             specific_editions,
         ),
         MintSubcommands::MissingEditions { keypair, account } => {
-            mint_missing_editions(client, &keypair, &account)
+            mint_missing_editions(&client, &keypair, &account)
         }
         MintSubcommands::List {
             keypair,
@@ -539,7 +547,7 @@ pub fn process_mint(client: &RpcClient, commands: MintSubcommands) -> Result<()>
             sign,
             track,
         } => mint_list(
-            client,
+            &client,
             keypair,
             receiver,
             nft_data_dir,

--- a/src/process_subcommands.rs
+++ b/src/process_subcommands.rs
@@ -325,7 +325,7 @@ pub fn process_create(client: RpcClient, commands: CreateSubcommands) -> Result<
         CreateSubcommands::Fungible {
             keypair,
             metadata,
-            mint,
+            mint_path,
             decimals,
             initial_supply,
             immutable,
@@ -333,7 +333,7 @@ pub fn process_create(client: RpcClient, commands: CreateSubcommands) -> Result<
             client,
             keypair,
             metadata,
-            mint,
+            mint_path,
             decimals,
             initial_supply,
             immutable,


### PR DESCRIPTION
User can now specify a keypair file to be used as the mint to allow creating NFTs and fungible tokens with vanity mint addresses.