### PR TITLE
Fix: `error processing instruction 0: 0x95` for `create-fungible`

### DIFF
--- a/src/create/methods.rs
+++ b/src/create/methods.rs
@@ -290,6 +290,7 @@ pub fn create_fungible(args: CreateFungibleArgs) -> Result<()> {
         .payer(keypair.pubkey())
         .update_authority(keypair.pubkey(), true)
         .create_args(create_args)
+        .spl_token_program(Some(spl_token::ID))
         .instruction();
 
     let mut instructions = vec![create_ix];


### PR DESCRIPTION
Probably due to https://github.com/metaplex-foundation/mpl-token-metadata/issues/140