### PR TITLE
fix: MacOS arch in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           - windows-latest
           - buildjet-16vcpu-ubuntu-2004
           - macos-latest
-          - macos-14
+          - macos-latest-large # intel
 
     runs-on: ${{ matrix.os }}
 
@@ -49,7 +49,7 @@ jobs:
             binary_path="metaboss-windows-latest${binary_extension}"
           fi
           if [[ "${RUNNER_OS}" == "macOS" ]]; then
-            if [[ "${MATRIX_OS}" == "macos-14" ]]; then
+            if [[ "${MATRIX_OS}" == "macos-latest" ]]; then
               binary_path="metaboss-macos-m1-latest"
             else
               binary_path="metaboss-macos-intel-latest"


### PR DESCRIPTION
GitHub runners now only offer intel runners for `macos-latest-large` images:
([source](https://github.com/actions/runner-images/blob/6cc2576b1b19c08317047523d5abe3c48a9eab98/README.md#available-images))

| Image | YAML Label |
| ------- |--------------|
| macOS 15 <sup>beta</sup> | `macos-15-large` |
| macOS 15 Arm64 <sup>beta</sup> | `macos-15` or `macos-15-xlarge` |
| macOS 14 | `macos-latest-large` or `macos-14-large` |
| macOS 14 Arm64 |`macos-latest`, `macos-14`, `macos-latest-xlarge` or `macos-14-xlarge` |

fixes #359 