### PR TITLE
refactor: replace unsafe unwraps with proper error context in get_largest_token_account_owner

### DIFF
--- a/src/airdrop/mod.rs
+++ b/src/airdrop/mod.rs
@@ -19,6 +19,7 @@ pub use solana_sdk::{pubkey::Pubkey, signer::Signer};
 pub use crate::update::{parse_keypair, parse_solana_config};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[allow(dead_code)]
 struct FailedTransaction {
     transaction_accounts: Vec<String>,
     recipients: HashMap<String, u64>,
@@ -26,6 +27,7 @@ struct FailedTransaction {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[allow(dead_code)]
 struct Recipient {
     address: String,
     amount: u64,

--- a/src/airdrop/spl.rs
+++ b/src/airdrop/spl.rs
@@ -25,6 +25,7 @@ pub struct AirdropSplArgs {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[allow(dead_code)]
 struct SplFailedTransaction {
     transaction_accounts: Vec<String>,
     recipients: HashMap<String, f64>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use borsh::{BorshDeserialize, BorshSerialize};
 use retry::{delay::Exponential, retry};
 use serde::Deserialize;
@@ -254,12 +254,14 @@ pub fn get_largest_token_account_owner(client: &RpcClient, mint: Pubkey) -> Resu
         method: "getTokenLargestAccounts",
     };
     let params = json!([mint.to_string(), { "commitment": "confirmed" }]);
-    let result: JRpcResponse = client.send(request, params)?;
+    let result: JRpcResponse = client
+        .send(request, params)
+        .context("Failed to get largest token accounts from RPC")?;
 
     let token_accounts: Vec<TokenAccount> = result
         .value
         .into_iter()
-        .filter(|account| account.amount.parse::<u64>().unwrap() == 1)
+        .filter(|account| account.amount.parse::<u64>().unwrap_or(0) == 1)
         .collect();
 
     if token_accounts.len() > 1 {
@@ -276,14 +278,24 @@ pub fn get_largest_token_account_owner(client: &RpcClient, mint: Pubkey) -> Resu
         ));
     }
 
-    let token_account = Pubkey::from_str(&token_accounts[0].address).unwrap();
+    let token_account = Pubkey::from_str(&token_accounts[0].address).map_err(|_| {
+        anyhow!(
+            "Invalid token account address: {}",
+            token_accounts[0].address
+        )
+    })?;
 
     let account = client
         .get_account_with_commitment(&token_account, CommitmentConfig::confirmed())
-        .unwrap()
+        .context(format!(
+            "Failed to get account data for token account {}",
+            token_account
+        ))?
         .value
-        .unwrap();
-    let account_data = Account::unpack(&account.data).unwrap();
+        .ok_or_else(|| anyhow!("Token account {} not found on-chain", token_account))?;
+
+    let account_data = Account::unpack(&account.data)
+        .context("Failed to unpack token account data (SPL Token format)")?;
 
     Ok(account_data.owner)
 }


### PR DESCRIPTION
### Overview
This PR improves the stability and error handling of the `get_largest_token_account_owner` function in `src/utils.rs`. Previously, the code relied on several `.unwrap()` calls which could cause the CLI to panic (crash) during network instability or when receiving unexpected RPC responses.

### Changes
- **Idiomatic Error Handling**: Replaced multiple `.unwrap()` calls with the `?` operator to propagate errors gracefully using `anyhow`.
- **Contextual Messages**: Added `.context()` to RPC calls and account unpacking to provide users with descriptive error messages instead of a thread panic.
- **Safe Parsing**: Updated token amount parsing to use `.unwrap_or(0)` to prevent crashes on malformed data.
- **Improved Validation**: Added explicit checks for missing token accounts using `ok_or_else` with meaningful error strings.

### Impact
The tool is now more robust against transient network failures and malformed on-chain data. Users will receive actionable error messages instead of an unhandled panic.

Verified with `cargo check`.