### PR TITLE
fix: correct stale flag names in error messages and add missing subcommand docs

### DIFF
--- a/src/mint.rs
+++ b/src/mint.rs
@@ -80,7 +80,7 @@ pub fn mint_list(
 ) -> Result<()> {
     if !is_only_one_option(&list_dir, &external_metadata_uris) {
         return Err(anyhow!(
-            "Only one of --list-dir or --external-metadata-uris can be specified"
+            "Only one of --nft-data-dir or --external-metadata-uris can be specified"
         ));
     }
     let max_editions = 0;
@@ -113,7 +113,7 @@ pub fn mint_list(
         )?;
     } else {
         return Err(anyhow!(
-            "Either --list-dir or --external-metadata-uris must be specified"
+            "Either --nft-data-dir or --external-metadata-uris must be specified"
         ));
     }
 
@@ -441,7 +441,7 @@ pub fn mint_one<P: AsRef<Path>>(
 ) -> Result<String> {
     if !is_only_one_option(&nft_data_file, &external_metadata_uri) {
         return Err(anyhow!(
-            "You must supply either --nft_data_file or --external-metadata-uris but not both"
+            "You must supply either --nft-data-file or --external-metadata-uri but not both"
         ));
     }
 
@@ -477,7 +477,7 @@ pub fn mint_one<P: AsRef<Path>>(
         }
     } else {
         return Err(anyhow!(
-            "You must supply either --nft_data_file or --external-metadata-uris but not both"
+            "You must supply either --nft-data-file or --external-metadata-uri but not both"
         ));
     };
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -166,7 +166,10 @@ pub enum Command {
 #[derive(Debug, StructOpt)]
 pub enum BurnSubcommands {
     /// Burn an asset.
-    #[structopt(name = "asset")]
+    #[structopt(
+        name = "asset",
+        after_help = "EXAMPLES:\nmetaboss burn asset --mint-account <MINT_ADDRESS>"
+    )]
     Asset {
         /// Path to the owner keypair file
         #[structopt(short, long)]
@@ -719,6 +722,7 @@ pub enum CollectionsSubcommands {
 
 #[derive(Debug, StructOpt)]
 pub enum DecodeSubcommands {
+    /// Decode BPF upgradeable loader state account data.
     BpfUpgradeableState {
         /// BpfUpgradeableState address
         #[structopt(short = "a", long)]
@@ -746,6 +750,7 @@ pub enum DecodeSubcommands {
         #[structopt(short = "a", long)]
         token_address: String,
     },
+    /// Decode a metadata delegate record account.
     MetadataDelegate {
         /// MetadataDelegate address
         #[structopt(short = "a", long)]
@@ -761,11 +766,13 @@ pub enum DecodeSubcommands {
         #[structopt(short = "m", long)]
         mint: Option<String>,
     },
+    /// Decode a collection authority record account.
     CollectionDelegate {
         /// CollectionAuthorityRecord address
         #[structopt(short = "a", long)]
         authority_record: String,
     },
+    /// Decode a use authority record account.
     UseDelegate {
         /// UseDelegate address
         #[structopt(short = "a", long)]
@@ -1071,7 +1078,10 @@ pub enum MintSubcommands {
         #[structopt(short = "P", long, default_value = "none")]
         priority: Priority,
     },
-    #[structopt(name = "list")]
+    #[structopt(
+        name = "list",
+        after_help = "EXAMPLES:\nmetaboss mint list --nft-data-dir <PATH_TO_METADATA_DIR>"
+    )]
     /// Mint a list of NFTs from a directory of JSON files
     List {
         /// Path to the update_authority's keypair file
@@ -1237,6 +1247,7 @@ pub enum SetSubcommands {
         #[structopt(short = "P", long, default_value = "none")]
         priority: Priority,
     },
+    /// Set is-mutable to false for a list of NFTs.
     ImmutableAll {
         /// Path to the update authority's keypair file
         #[structopt(short, long)]
@@ -1917,6 +1928,7 @@ pub enum UpdateSubcommands {
 
 #[derive(Debug, StructOpt)]
 pub enum TransferSubcommands {
+    /// Transfer a Metaplex asset.
     Asset {
         /// Path to the update_authority keypair file
         #[structopt(short, long)]
@@ -1947,6 +1959,7 @@ pub enum TransferSubcommands {
 
 #[derive(Debug, StructOpt)]
 pub enum VerifySubcommands {
+    /// Verify a creator for a single NFT.
     Creator {
         /// Path to the update_authority keypair file
         #[structopt(short, long)]
@@ -1961,6 +1974,7 @@ pub enum VerifySubcommands {
         #[structopt(short = "P", long, default_value = "none")]
         priority: Priority,
     },
+    /// Verify a creator for a list of NFTs.
     CreatorAll {
         /// Path to the update_authority keypair file
         #[structopt(short, long)]
@@ -1991,6 +2005,7 @@ pub enum VerifySubcommands {
 
 #[derive(Debug, StructOpt)]
 pub enum UnverifySubcommands {
+    /// Unverify a creator for a single NFT.
     Creator {
         /// Path to the update_authority keypair file
         #[structopt(short, long)]
@@ -2005,6 +2020,7 @@ pub enum UnverifySubcommands {
         #[structopt(short = "P", long, default_value = "none")]
         priority: Priority,
     },
+    /// Unverify a creator for a list of NFTs.
     CreatorAll {
         /// Path to the update_authority keypair file
         #[structopt(short, long)]

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -71,7 +71,7 @@ pub fn sign_all(
 
     if !is_only_one_option(creator, &mint_accounts_file) {
         return Err(anyhow!(
-            "Must specify exactly one of --candy-machine-id or --mint-data-dir"
+            "Must specify exactly one of --creator or --mint-accounts-file"
         ));
     }
 

--- a/src/snapshot/methods.rs
+++ b/src/snapshot/methods.rs
@@ -17,7 +17,7 @@ use crate::{constants::*, decode::get_metadata_pda};
 pub fn snapshot_mints_gpa(client: RpcClient, args: SnapshotMintsGpaArgs) -> Result<()> {
     if !is_only_one_option(&args.creator, &args.update_authority) {
         return Err(anyhow!(
-            "Please specify either a candy machine id or an update authority, but not both."
+            "Please specify either a creator or an update authority, but not both."
         ));
     }
 
@@ -27,7 +27,7 @@ pub fn snapshot_mints_gpa(client: RpcClient, args: SnapshotMintsGpaArgs) -> Resu
         creator.clone()
     } else {
         return Err(anyhow!(
-            "Must specify either --update-authority or --candy-machine-id"
+            "Must specify either --update-authority or --creator"
         ));
     };
 
@@ -108,7 +108,7 @@ pub fn get_mint_accounts(
         }
     } else {
         return Err(anyhow!(
-            "Please specify either a candy machine id or an update authority, but not both."
+            "Please specify either a creator or an update authority, but not both."
         ));
     };
     spinner.finish();
@@ -160,7 +160,7 @@ pub fn snapshot_holders_gpa(client: RpcClient, args: SnapshotHoldersGpaArgs) -> 
         get_mint_account_infos(&client, mint_accounts)?
     } else {
         return Err(anyhow!(
-            "Must specify either --update-authority or --candy-machine-id or --mint-accounts-file"
+            "Must specify either --update-authority or --creator or --mint-accounts-file"
         ));
     };
     spinner.finish_with_message("Getting accounts...Done!");
@@ -260,7 +260,7 @@ pub fn snapshot_holders_gpa(client: RpcClient, args: SnapshotHoldersGpaArgs) -> 
         str::replace(&mint_accounts_file, ".json", "")
     } else {
         return Err(anyhow!(
-            "Must specify either --update-authority or --candy-machine-id or --mint-accounts-file"
+            "Must specify either --update-authority or --creator or --mint-accounts-file"
         ));
     };
 


### PR DESCRIPTION
Several error messages referenced flags that no longer exist, 
and 10 subcommand variants had no help text at all.