### PR TITLE
fix: honor --output path in DAS snapshot commands

### DIFF
--- a/src/snapshot/das_api.rs
+++ b/src/snapshot/das_api.rs
@@ -198,10 +198,11 @@ pub async fn snapshot_holders(args: HoldersArgs) -> Result<()> {
         holders.sort();
 
         // Write to file
-        let file = File::create(format!(
+        std::fs::create_dir_all(&args.output)?;
+        let file = File::create(args.output.join(format!(
             "{}_{}_holders.json",
             args.group_value, args.group_key
-        ))?;
+        )))?;
         serde_json::to_writer_pretty(file, &holders)?;
     }
 
@@ -209,7 +210,11 @@ pub async fn snapshot_holders(args: HoldersArgs) -> Result<()> {
         token_holders.sort_by(|a, b| a.owner.cmp(&b.owner));
 
         // Write to file
-        let file = File::create(format!("{}_token_holders.json", args.group_value))?;
+        std::fs::create_dir_all(&args.output)?;
+        let file = File::create(
+            args.output
+                .join(format!("{}_token_holders.json", args.group_value)),
+        )?;
         serde_json::to_writer_pretty(file, &token_holders)?;
     }
 
@@ -364,10 +369,11 @@ pub async fn snapshot_mints(args: MintsArgs) -> Result<()> {
     mints.sort();
 
     // Write to file
-    let file = File::create(format!(
+    std::fs::create_dir_all(&args.output)?;
+    let file = File::create(args.output.join(format!(
         "{}_{}_mints.json",
         args.group_value, args.group_key
-    ))?;
+    )))?;
     serde_json::to_writer_pretty(file, &mints)?;
 
     Ok(())
@@ -455,7 +461,8 @@ pub async fn fcva_mints(args: FcvaArgs) -> Result<()> {
     mints.sort();
 
     // Write to file
-    let file = File::create(format!("{}_fvca_mints.json", creator))?;
+    std::fs::create_dir_all(&args.output)?;
+    let file = File::create(args.output.join(format!("{}_fvca_mints.json", creator)))?;
     serde_json::to_writer_pretty(file, &mints)?;
 
     Ok(())
@@ -529,7 +536,8 @@ pub async fn mcc_mints(args: MccArgs) -> Result<()> {
     mints.sort();
 
     // Write to file
-    let file = File::create(format!("{}_mcc_mints.json", mcc_id))?;
+    std::fs::create_dir_all(&args.output)?;
+    let file = File::create(args.output.join(format!("{}_mcc_mints.json", mcc_id)))?;
     serde_json::to_writer_pretty(file, &mints)?;
 
     Ok(())

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -1,0 +1,83 @@
+mod common;
+
+use anyhow::Result;
+use common::TestContext;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+#[test]
+#[ignore]
+fn test_snapshot_fvca_honors_output_flag() -> Result<()> {
+    let stub_pubkey = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+    // Setup test context and output directory
+    let mut ctx = TestContext::new()?;
+    let temp_dir = ctx.create_temp_dir("snapshot_fvca_test");
+    let temp_dir_str = temp_dir.to_string_lossy().to_string();
+
+    // Start a mock DAS RPC server that returns a valid JSON-RPC response
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let mock_url = format!("http://127.0.0.1:{}", port);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"result":{"total":1,"limit":1000,"page":1,"items":[{"interface":"V1_NFT","id":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","content":{},"authorities":[],"compression":{},"grouping":{},"royalty":{},"creators":[{"address":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","verified":true,"share":100}],"ownership":{"delegate":null,"delegated":false,"frozen":false,"owner":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","ownership_model":"single"},"supply":{},"mutable":true,"burnt":false}]}}"#;
+
+    // The mock server handles two requests: one with data and an empty one to end the loop
+    thread::spawn(move || {
+        let mut count = 0;
+        while count < 2 {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buffer = [0; 1024];
+                let _ = stream.read(&mut buffer);
+
+                let current_body = if count == 0 {
+                    body.to_string()
+                } else {
+                    r#"{"jsonrpc":"2.0","id":1,"result":{"total":0,"limit":1000,"page":2,"items":[]}}"#
+                        .to_string()
+                };
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    current_body.len(),
+                    current_body
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+                count += 1;
+            }
+        }
+    });
+
+    // Run metaboss command against the mock server
+    let output = ctx.run_metaboss(&[
+        "snapshot",
+        "fvca",
+        stub_pubkey,
+        "--rpc",
+        &mock_url,
+        "--output",
+        &temp_dir_str,
+    ]);
+    common::assert_success(&output);
+
+    let expected_filename = format!("{}_fvca_mints.json", stub_pubkey);
+
+    let in_output_dir = temp_dir.join(&expected_filename).exists();
+    let in_cwd = std::env::current_dir()
+        .unwrap()
+        .join(&expected_filename)
+        .exists();
+
+    // Verification: Currently, Metaboss buggy behavior writes to CWD instead of the output dir
+    assert!(in_cwd, "file should be in CWD (current buggy behavior)");
+    assert!(!in_output_dir, "file should NOT be in output dir yet");
+
+    // Cleanup leaked file
+    if in_cwd {
+        let _ = std::fs::remove_file(std::env::current_dir().unwrap().join(&expected_filename));
+    }
+
+    Ok(())
+}

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -70,9 +70,9 @@ fn test_snapshot_fvca_honors_output_flag() -> Result<()> {
         .join(&expected_filename)
         .exists();
 
-    // Verification: Currently, Metaboss buggy behavior writes to CWD instead of the output dir
-    assert!(in_cwd, "file should be in CWD (current buggy behavior)");
-    assert!(!in_output_dir, "file should NOT be in output dir yet");
+    // The file should be in the output dir
+    assert!(in_output_dir, "file should be in output dir");
+    assert!(!in_cwd, "file should NOT be in CWD anymore");
 
     // Cleanup leaked file
     if in_cwd {


### PR DESCRIPTION
Snapshot commands accepted `--output` but always wrote files 
to the current working directory.

Includes a regression test with a mock DAS server.