### PR TITLE
fix: gracefully handle missing mint during cache resume in batch updates

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -335,7 +335,16 @@ pub trait Action {
                 let new_value = match &args.new_value {
                     NewValue::None => &empty_string,
                     NewValue::Single(value) => value,
-                    NewValue::List(values) => values.get(&mint_address).unwrap(),
+                    NewValue::List(values) => match values.get(&mint_address) {
+                        Some(v) => v,
+                        None => {
+                            return Err(ActionError::ActionFailed(
+                                mint_address.clone(),
+                                "mint found in cache but missing from input list".to_string(),
+                            )
+                            .into());
+                        }
+                    },
                 };
 
                 // Create task to run the action in a separate thread.

--- a/tests/update_tests.rs
+++ b/tests/update_tests.rs
@@ -322,3 +322,57 @@ fn test_update_creators_all_append() -> Result<()> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Test 7: Resume update uri-all with a cache file containing a mint not present
+// in the new URIs file. This should currently panic.
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "requires solana-test-validator (run with --ignored)"]
+fn test_uri_all_resume_missing_mint_panics() -> Result<()> {
+    // Initialize context
+    let mut ctx = TestContext::new()?;
+    let temp_dir = ctx.create_temp_dir("uri-all-resume-panic");
+
+    // Mint a real NFT
+    let mint = mint_test_nft(&ctx, &temp_dir)?;
+
+    // Create cache file with the mint
+    let cache_file = temp_dir.join("resume_cache.json");
+    let cache_data = serde_json::json!({
+        mint: {
+            "error": "Simulated failure"
+        }
+    });
+    std::fs::write(&cache_file, serde_json::to_string(&cache_data)?)?;
+    let cache_file_str = cache_file.to_string_lossy().to_string();
+
+    // Create new_uris_file that is empty (mint removed by user)
+    let new_uris_file = temp_dir.join("new_uris.json");
+    let new_uris_data: Vec<serde_json::Value> = vec![];
+    std::fs::write(&new_uris_file, serde_json::to_string(&new_uris_data)?)?;
+    let new_uris_file_str = new_uris_file.to_string_lossy().to_string();
+
+    // Run metaboss update uri-all
+    let output = ctx.run_metaboss(&[
+        "update",
+        "uri-all",
+        "-k",
+        &ctx.keypair_path,
+        "--new-uris-file",
+        &new_uris_file_str,
+        "--cache-file",
+        &cache_file_str,
+    ]);
+
+    // Current buggy behavior: process should have panicked
+    assert!(!output.success, "bug: process should have panicked/crashed");
+
+    assert!(
+        output.stderr.contains("panicked") || output.stderr.contains("unwrap"),
+        "bug: expected panic in stderr, got: {}",
+        output.stderr
+    );
+
+    Ok(())
+}

--- a/tests/update_tests.rs
+++ b/tests/update_tests.rs
@@ -324,12 +324,12 @@ fn test_update_creators_all_append() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Test 7: Resume update uri-all with a cache file containing a mint not present
-// in the new URIs file. This should currently panic.
+// Test 7: update uri-all resume should not panic when a mint from the cache
+// is missing from the new-uris file
 // ---------------------------------------------------------------------------
 #[test]
 #[ignore = "requires solana-test-validator (run with --ignored)"]
-fn test_uri_all_resume_missing_mint_panics() -> Result<()> {
+fn test_uri_all_resume_missing_mint_fails_gracefully() -> Result<()> {
     // Initialize context
     let mut ctx = TestContext::new()?;
     let temp_dir = ctx.create_temp_dir("uri-all-resume-panic");
@@ -365,12 +365,23 @@ fn test_uri_all_resume_missing_mint_panics() -> Result<()> {
         &cache_file_str,
     ]);
 
-    // Current buggy behavior: process should have panicked
-    assert!(!output.success, "bug: process should have panicked/crashed");
+    // process should fail but not panic
+    assert!(
+        !output.success,
+        "Command should fail when mint is missing from input list"
+    );
 
     assert!(
-        output.stderr.contains("panicked") || output.stderr.contains("unwrap"),
-        "bug: expected panic in stderr, got: {}",
+        !output.stderr.contains("panicked") && !output.stderr.contains("unwrap"),
+        "Process panicked in stderr: {}",
+        output.stderr
+    );
+
+    assert!(
+        output
+            .stderr
+            .contains("mint found in cache but missing from input list"),
+        "Missing expected error message in stderr: {}",
         output.stderr
     );
 


### PR DESCRIPTION
Resuming a batch update with `--cache-file` would panic if a mint 
was removed from the input list between runs. The `.unwrap()` on 
the missing map entry crashed the process instead of reporting 
which mint was missing.

Includes a regression test.